### PR TITLE
ci: fix pnpm cache setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: pnpm
 
       - name: Enable Corepack
         run: corepack enable


### PR DESCRIPTION
Fix CI failure where actions/setup-node with cache: pnpm errors because pnpm isn't on PATH during the setup-node step (seen on Dependabot run 21615963781). Remove pnpm cache for now; corepack enables pnpm for install/test/build.\n\nFollow-up: we can re-add caching using pnpm/action-setup + actions/cache once stable.