### PR TITLE
ci: provide dummy OPENAI_API_KEY for unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    env:
+      # Unit tests should not require real credentials; a placeholder avoids
+      # OpenAI client construction failures inside compaction session wrappers.
+      OPENAI_API_KEY: test
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
CI tests were failing with 'Missing credentials' because SessionStore wraps sessions with OpenAIResponsesCompactionSession, which constructs an OpenAI client and requires OPENAI_API_KEY to be set. Unit tests don't actually call the network, so we provide a dummy key in the CI job env to prevent constructor failure.