### PR TITLE
SessionStore: avoid OpenAI compaction without credentials

### DIFF
--- a/src/gateway/admin.test.ts
+++ b/src/gateway/admin.test.ts
@@ -34,7 +34,7 @@ const makeSessionStore = async () => {
   // SessionStore persists to disk by default. Use an isolated temp directory in tests
   // to avoid cross-test contamination from previous runs.
   const baseDir = await mkdtemp(path.join(os.tmpdir(), 'halo-sessions-'));
-  return new SessionStore({ baseDir });
+  return new SessionStore({ baseDir, compactionEnabled: false });
 };
 
 describe('gateway status handler', () => {

--- a/src/sessions/sessionStore.test.ts
+++ b/src/sessions/sessionStore.test.ts
@@ -25,7 +25,7 @@ describe('SessionStore', () => {
   });
 
   it('returns the same session instance for the same scopeId', async () => {
-    const store = new SessionStore({ baseDir: tempDir });
+    const store = new SessionStore({ baseDir: tempDir, compactionEnabled: false });
 
     const a1 = store.getOrCreate('scope-a');
     const a2 = store.getOrCreate('scope-a');
@@ -34,7 +34,7 @@ describe('SessionStore', () => {
   });
 
   it('isolates history across different scopeIds', async () => {
-    const store = new SessionStore({ baseDir: tempDir });
+    const store = new SessionStore({ baseDir: tempDir, compactionEnabled: false });
 
     const s1 = store.getOrCreate('scope-1');
     const s2 = store.getOrCreate('scope-2');
@@ -51,7 +51,7 @@ describe('SessionStore', () => {
   });
 
   it('can clear a scope session without affecting others', async () => {
-    const store = new SessionStore({ baseDir: tempDir });
+    const store = new SessionStore({ baseDir: tempDir, compactionEnabled: false });
 
     const s1 = store.getOrCreate('scope-1');
     const s2 = store.getOrCreate('scope-2');
@@ -70,11 +70,11 @@ describe('SessionStore', () => {
   });
 
   it('reloads history when a new store is created', async () => {
-    const store1 = new SessionStore({ baseDir: tempDir });
+    const store1 = new SessionStore({ baseDir: tempDir, compactionEnabled: false });
     const session1 = store1.getOrCreate('scope-persist');
     await session1.addItems([userMessage('persist me')]);
 
-    const store2 = new SessionStore({ baseDir: tempDir });
+    const store2 = new SessionStore({ baseDir: tempDir, compactionEnabled: false });
     const session2 = store2.getOrCreate('scope-persist');
 
     expect(await session2.getItems()).toEqual([userMessage('persist me')]);


### PR DESCRIPTION
Production-ready fix: SessionStore now only wraps sessions with OpenAIResponsesCompactionSession when compaction is enabled AND credentials are available (OPENAI_API_KEY), or when explicitly enabled via options/env. This prevents unit tests/CI (and other environments) from failing just by constructing sessions.

- Adds SessionStoreOptions.compactionEnabled (default: true only when OPENAI_API_KEY present; overridable via HALO_COMPACTION_ENABLED).
- Updates tests to set compactionEnabled:false explicitly.

Follow-up: we can remove the CI dummy OPENAI_API_KEY once this lands.