### PR TITLE
chore: make readiness checks usable in main checkout

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,12 @@ const complexityThreshold = 15;
 
 export default [
   {
-    ignores: ["dist/**", "node_modules/**"],
+    ignores: [
+      "dist/**",
+      "node_modules/**",
+      ".ralph-worktrees/**",
+      "apps/admin/src-tauri/target/**",
+    ],
   },
   {
     files: ["**/*.{js,cjs,mjs,ts,tsx}"],

--- a/jscpd.json
+++ b/jscpd.json
@@ -7,6 +7,7 @@
   "ignore": [
     "**/node_modules/**",
     "**/dist/**",
+    "**/.ralph-worktrees/**",
     "**/logs/**",
     "**/memory/**",
     "**/reports/**",

--- a/knip.json
+++ b/knip.json
@@ -3,7 +3,8 @@
   "entry": [
     "src/interfaces/telegram/start.ts",
     "src/interfaces/cli/run.ts",
-    "src/gateway/start.ts"
+    "src/gateway/start.ts",
+    "src/dev/todoCheck.ts"
   ],
   "project": [
     "src/**/*.ts",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "check:deadcode": "knip",
     "check:complexity": "eslint .",
     "check:dup": "jscpd --config jscpd.json",
+    "check:todo": "tsx src/dev/todoCheck.ts",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/src/dev/todoCheck.ts
+++ b/src/dev/todoCheck.ts
@@ -22,6 +22,7 @@ const ignoredDirs = new Set([
   ".git",
   ".pnpm-store",
   ".turbo",
+  ".ralph-worktrees",
   "archive",
   "coverage",
   "dist",
@@ -78,6 +79,11 @@ const scanFile = (
   const text = buffer.toString("utf8");
   const lines = text.split(/\r?\n/);
   const relativePath = relative(rootDir, filePath) || filePath;
+
+  // Avoid flagging the checker implementation itself.
+  if (relativePath.replace(/\\/g, '/') === 'src/dev/todoCheck.ts') {
+    return;
+  }
 
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index] ?? "";

--- a/src/gateway/admin.ts
+++ b/src/gateway/admin.ts
@@ -11,7 +11,7 @@ export type HaloHomePaths = {
   memory: string;
 };
 
-export type GatewayStatus = {
+type GatewayStatus = {
   uptime: number;
   version: string | null;
   haloHome: HaloHomePaths;
@@ -130,7 +130,7 @@ export async function resolveVersion(root: string): Promise<string | null> {
   }
 }
 
-export function createStatusPayload(context: StatusContext): GatewayStatus {
+function createStatusPayload(context: StatusContext): GatewayStatus {
   const now = context.now ? context.now() : Date.now();
   const uptime = Math.max(0, (now - context.startedAtMs) / 1000);
 

--- a/src/interfaces/telegram/bot.ts
+++ b/src/interfaces/telegram/bot.ts
@@ -17,7 +17,7 @@ export type TelegramBotLike = {
   start: () => Promise<void>;
 };
 
-export type TelegramAdapterDeps = {
+type TelegramAdapterDeps = {
   runPrime: typeof runPrime;
   appendDailyNote: typeof appendDailyNote;
   appendJsonl: typeof appendJsonl;

--- a/src/prime/prime.ts
+++ b/src/prime/prime.ts
@@ -33,7 +33,7 @@ const rememberDaily = tool({
   },
 });
 
-export async function makePrimeAgent() {
+async function makePrimeAgent() {
   const rootDir = process.cwd();
   const ctx = await loadMarkdownContextFiles({ rootDir });
 


### PR DESCRIPTION
Agent-readiness added knip/jscpd/eslint checks, but they were noisy/broken when run from the main checkout due to:
- worktree artifacts (.ralph-worktrees) being scanned
- todoCheck scanning itself
- unused exported symbols flagged by knip

This PR:
- ignores .ralph-worktrees in eslint + jscpd + todoCheck
- makes compaction helper exports internal (avoids knip unused exports)
- adds check:todo script and registers todoCheck as a knip entry

Verified locally: pnpm test/build/check:deadcode/check:todo/check:dup.