### PR TITLE
docs: upgrade PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,32 @@
-## What changed
+## Summary
 - 
 
-## How tested
+## PRD / loop linkage (if applicable)
+- PRD (link or path):
+- Story IDs covered (e.g., AR9, A4):
+- Loop run/progress (optional):
+
+## Verification (check all that apply)
 - [ ] `pnpm test`
 - [ ] `pnpm build`
-- [ ] Other (describe): 
+- [ ] `pnpm check:deadcode`
+- [ ] `pnpm check:dup`
+- [ ] `pnpm check:todo`
+- [ ] CI green
+- [ ] Other (describe):
 
-## UI screenshots (if relevant)
+## Safety / boundaries
+- [ ] No secrets committed (env/log/session files checked)
+- [ ] No breaking changes to persisted state (HALO_HOME) without migration notes
+- [ ] Any new admin endpoints documented; default binding remains localhost-safe
+
+## UI / screenshots (if relevant)
 - [ ] Not applicable
 - Screenshots:
 
-## Risk / rollback notes
+## Risk / rollback
 - Risk level: Low / Medium / High
 - Rollback plan:
+
+## Follow-ups
+- 


### PR DESCRIPTION
Upgrade the PR template to better support autonomous Ralph-style loops: adds PRD/story linkage, verification checklist for new repo checks, safety/boundary prompts (secrets + HALO_HOME persistence + localhost binding), and follow-ups.