### PR TITLE
ci: run readiness checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    env:
-      # Unit tests should not require real credentials; a placeholder avoids
-      # OpenAI client construction failures inside compaction session wrappers.
-      OPENAI_API_KEY: test
-
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -39,3 +34,12 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+      - name: Deadcode
+        run: pnpm check:deadcode
+
+      - name: Duplication
+        run: pnpm check:dup
+
+      - name: Tech debt marker convention
+        run: pnpm check:todo


### PR DESCRIPTION
Run the checks introduced by the agent-readiness loop in CI (deadcode via knip, duplication via jscpd, and tech-debt marker convention). Also remove the dummy OPENAI_API_KEY now that SessionStore compaction is optional without credentials.