### PR TITLE
feat(admin): show sessions + clear

### DIFF
--- a/apps/admin/frontend/index.html
+++ b/apps/admin/frontend/index.html
@@ -26,6 +26,19 @@
           <button class="status__button" type="button" data-status-retry>Retry</button>
         </div>
       </div>
+      <div class="status" role="status" aria-live="polite" data-sessions-card>
+        <div class="status__header">
+          <div>
+            <div class="status__title" data-sessions-title>Sessions</div>
+            <div class="status__gateway" data-sessions-gateway>http://127.0.0.1:8787</div>
+          </div>
+          <div class="status__meta" data-sessions-meta>Checking...</div>
+        </div>
+        <div class="status__payload" data-sessions-payload>Loading sessions...</div>
+        <div class="status__actions">
+          <button class="status__button" type="button" data-sessions-retry>Refresh</button>
+        </div>
+      </div>
       <footer>
         <small>apps/admin/frontend</small>
       </footer>

--- a/apps/admin/frontend/sessions.js
+++ b/apps/admin/frontend/sessions.js
@@ -1,0 +1,32 @@
+export const buildSessionsUrl = (gatewayBase) => {
+  const base = gatewayBase.endsWith('/') ? gatewayBase.slice(0, -1) : gatewayBase;
+  return `${base}/sessions-with-counts`;
+};
+
+export const buildClearSessionUrl = (gatewayBase, scopeId) => {
+  const base = gatewayBase.endsWith('/') ? gatewayBase.slice(0, -1) : gatewayBase;
+  return `${base}/sessions/${encodeURIComponent(scopeId)}/clear`;
+};
+
+export const formatSessionsError = (error, gatewayBase) => {
+  const reason = error instanceof Error ? error.message : String(error);
+  return [
+    'Load failed.',
+    '',
+    `Make sure the gateway is running at ${gatewayBase}.`,
+    '',
+    `Details: ${reason}`,
+  ].join('\n');
+};
+
+export const formatSessionsPayload = (sessions) => {
+  if (!Array.isArray(sessions)) {
+    return JSON.stringify(sessions, null, 2);
+  }
+
+  const lines = sessions.map(({ scopeId, itemCount }) => {
+    return `- ${scopeId} (${itemCount}) [clear]`;
+  });
+
+  return lines.length ? lines.join('\n') : '(no sessions yet)';
+};

--- a/apps/admin/frontend/styles.css
+++ b/apps/admin/frontend/styles.css
@@ -133,3 +133,20 @@ footer {
   margin-top: 8px;
   color: #7b6d5b;
 }
+
+.sessions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.sessions__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.sessions__label {
+  overflow-wrap: anywhere;
+}

--- a/src/apps/admin/adminSessions.test.ts
+++ b/src/apps/admin/adminSessions.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildClearSessionUrl,
+  buildSessionsUrl,
+  formatSessionsError,
+  formatSessionsPayload,
+} from './sessions.js';
+
+describe('admin sessions helpers', () => {
+  it('buildSessionsUrl appends sessions-with-counts', () => {
+    expect(buildSessionsUrl('http://127.0.0.1:8787')).toBe(
+      'http://127.0.0.1:8787/sessions-with-counts',
+    );
+    expect(buildSessionsUrl('http://127.0.0.1:8787/')).toBe(
+      'http://127.0.0.1:8787/sessions-with-counts',
+    );
+  });
+
+  it('buildClearSessionUrl encodes scope id', () => {
+    expect(buildClearSessionUrl('http://x', 'telegram:889348242')).toBe(
+      'http://x/sessions/telegram%3A889348242/clear',
+    );
+  });
+
+  it('formatSessionsPayload renders json', () => {
+    expect(formatSessionsPayload([{ scopeId: 'a', itemCount: 1 }])).toBe(
+      '[\n  {\n    "scopeId": "a",\n    "itemCount": 1\n  }\n]',
+    );
+  });
+
+  it('formatSessionsError includes gateway base', () => {
+    const text = formatSessionsError(new Error('nope'), 'http://g');
+    expect(text).toContain('http://g');
+    expect(text).toContain('nope');
+  });
+});

--- a/src/apps/admin/sessions.ts
+++ b/src/apps/admin/sessions.ts
@@ -1,0 +1,29 @@
+type SessionSummary = {
+  scopeId: string;
+  itemCount: number;
+};
+
+export const buildSessionsUrl = (gatewayBase: string): string => {
+  const base = gatewayBase.endsWith('/') ? gatewayBase.slice(0, -1) : gatewayBase;
+  return `${base}/sessions-with-counts`;
+};
+
+export const buildClearSessionUrl = (gatewayBase: string, scopeId: string): string => {
+  const base = gatewayBase.endsWith('/') ? gatewayBase.slice(0, -1) : gatewayBase;
+  return `${base}/sessions/${encodeURIComponent(scopeId)}/clear`;
+};
+
+export const formatSessionsError = (error: unknown, gatewayBase: string): string => {
+  const reason = error instanceof Error ? error.message : String(error);
+  return [
+    'Load failed.',
+    '',
+    `Make sure the gateway is running at ${gatewayBase}.`,
+    '',
+    `Details: ${reason}`,
+  ].join('\n');
+};
+
+export const formatSessionsPayload = (sessions: unknown): string => {
+  return JSON.stringify(sessions, null, 2);
+};


### PR DESCRIPTION
Adds a Sessions card to the Tauri admin frontend.

- Fetches  and renders scopeId + itemCount.
- Adds Clear button per session ().
- Includes typed helper mirror  + tests.

Manual test:
- Start gateway (
> openai-agents@1.0.0 start:gateway /Users/nags/.openclaw/workspace/openai-agents
> node dist/gateway/start.js

halo (gateway) starting…
 ELIFECYCLE  Command failed with exit code 1.)
- Start admin app (
> admin@0.1.0 tauri:dev /Users/nags/.openclaw/workspace/openai-agents/apps/admin
> tauri dev


> admin@0.1.0 dev /Users/nags/.openclaw/workspace/openai-agents/apps/admin
> vite

 ELIFECYCLE  Command failed with exit code 1.
 ELIFECYCLE  Command failed with exit code 1.)
- Send a Telegram DM to halo, then verify session appears and can be cleared.