### PR TITLE
apps/admin: sessions viewer + clear

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ dist
 
 # apps/admin: per-app lockfile (keep root lockfile as source of truth)
 /apps/admin/pnpm-lock.yaml
+/apps/admin/src-tauri/gen/

--- a/apps/admin/frontend/index.html
+++ b/apps/admin/frontend/index.html
@@ -34,7 +34,8 @@
           </div>
           <div class="status__meta" data-sessions-meta>Checking...</div>
         </div>
-        <div class="status__payload" data-sessions-payload>Loading sessions...</div>
+        <div class="status__payload" data-sessions-list>Loading sessions...</div>
+        <pre class="status__payload" data-sessions-payload hidden></pre>
         <div class="status__actions">
           <button class="status__button" type="button" data-sessions-retry>Refresh</button>
         </div>

--- a/apps/admin/frontend/main.js
+++ b/apps/admin/frontend/main.js
@@ -21,6 +21,7 @@ const statusRetry = document.querySelector('[data-status-retry]');
 const sessionsCard = document.querySelector('[data-sessions-card]');
 const sessionsTitle = document.querySelector('[data-sessions-title]');
 const sessionsMeta = document.querySelector('[data-sessions-meta]');
+const sessionsList = document.querySelector('[data-sessions-list]');
 const sessionsPayload = document.querySelector('[data-sessions-payload]');
 const sessionsGateway = document.querySelector('[data-sessions-gateway]');
 const sessionsRetry = document.querySelector('[data-sessions-retry]');
@@ -110,14 +111,22 @@ const setSessionsLoading = () => {
   sessionsCard?.classList.remove('status--error');
   if (sessionsTitle) sessionsTitle.textContent = 'Sessions';
   if (sessionsMeta) sessionsMeta.textContent = 'Checking...';
-  if (sessionsPayload) sessionsPayload.textContent = 'Loading sessions...';
+  if (sessionsList) sessionsList.textContent = 'Loading sessions...';
+  if (sessionsPayload) {
+    sessionsPayload.hidden = true;
+    sessionsPayload.textContent = '';
+  }
 };
 
 const setSessionsError = (error) => {
   sessionsCard?.classList.add('status--error');
   if (sessionsTitle) sessionsTitle.textContent = 'Sessions unavailable';
   if (sessionsMeta) sessionsMeta.textContent = 'Unavailable';
-  if (sessionsPayload) sessionsPayload.textContent = formatSessionsError(error, gatewayBase);
+  if (sessionsList) sessionsList.textContent = formatSessionsError(error, gatewayBase);
+  if (sessionsPayload) {
+    sessionsPayload.hidden = true;
+    sessionsPayload.textContent = '';
+  }
 };
 
 const setSessionsSuccess = (payload) => {
@@ -125,10 +134,9 @@ const setSessionsSuccess = (payload) => {
   if (sessionsTitle) sessionsTitle.textContent = 'Sessions';
   if (sessionsMeta) sessionsMeta.textContent = `Updated ${new Date().toLocaleTimeString()}`;
 
-  if (sessionsPayload) {
-    // Render a clickable list (clear buttons) when the payload matches expected shape.
+  if (sessionsList) {
     if (Array.isArray(payload)) {
-      sessionsPayload.textContent = '';
+      sessionsList.textContent = '';
       const list = document.createElement('div');
       list.className = 'sessions';
 
@@ -155,10 +163,15 @@ const setSessionsSuccess = (payload) => {
         }
       }
 
-      sessionsPayload.appendChild(list);
+      sessionsList.appendChild(list);
     } else {
-      sessionsPayload.textContent = formatSessionsPayload(payload);
+      sessionsList.textContent = formatSessionsPayload(payload);
     }
+  }
+
+  if (sessionsPayload) {
+    sessionsPayload.hidden = true;
+    sessionsPayload.textContent = formatSessionsPayload(payload);
   }
 };
 
@@ -207,7 +220,7 @@ sessionsRetry?.addEventListener('click', () => {
   void refreshSessions();
 });
 
-sessionsPayload?.addEventListener('click', async (event) => {
+sessionsList?.addEventListener('click', async (event) => {
   const target = event.target;
   if (!(target instanceof HTMLElement)) return;
   const button = target.closest('[data-clear-scope-id]');

--- a/apps/admin/frontend/styles.css
+++ b/apps/admin/frontend/styles.css
@@ -114,6 +114,26 @@ h1 {
   outline-offset: 2px;
 }
 
+.sessions {
+  display: grid;
+  gap: 10px;
+}
+
+.sessions__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.sessions__label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .status--error {
   background: #ffe6e6;
   border-color: #e9a2a2;


### PR DESCRIPTION
Adds a Sessions card to the Tauri admin frontend.

- Fetches  and renders a list of scopeIds + item counts.
- Adds per-scope **Clear** buttons that call  and refresh.
- Ignores  artifacts.

Manual test:
1) Run gateway + create a telegram session.
2) Launch undefined
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "tauri:dev" not found (apps/admin)
3) Confirm sessions render and Clear works.