### PR TITLE
feat: scoped memory per conversation scope

### DIFF
--- a/src/interfaces/telegram/bot.test.ts
+++ b/src/interfaces/telegram/bot.test.ts
@@ -71,7 +71,7 @@ describe('telegram adapter', () => {
       rootDir: '/root',
       bot,
       now,
-      deps: { appendJsonl, appendDailyNote, runPrime, loadFamilyConfig },
+      deps: { appendJsonl, appendScopedDailyNote: appendDailyNote, runPrime, loadFamilyConfig },
     });
 
     const reply = vi.fn().mockResolvedValue(undefined);
@@ -91,9 +91,10 @@ describe('telegram adapter', () => {
       channel: 'telegram',
       userId: '456',
       scopeId: 'telegram:dm:wags',
+      rootDir: '/root',
     });
-    expect(appendDailyNote).toHaveBeenCalledWith({ rootDir: '/root' }, '[user] hello');
-    expect(appendDailyNote).toHaveBeenCalledWith({ rootDir: '/root' }, '[prime] hi there');
+    expect(appendDailyNote).toHaveBeenCalledWith({ rootDir: '/root', scopeId: 'telegram:dm:wags' }, '[user] hello');
+    expect(appendDailyNote).toHaveBeenCalledWith({ rootDir: '/root', scopeId: 'telegram:dm:wags' }, '[prime] hi there');
     expect(reply).toHaveBeenCalledWith('hi there');
 
     expect(appendJsonl).toHaveBeenCalledTimes(3);
@@ -112,7 +113,7 @@ describe('telegram adapter', () => {
     createTelegramAdapter({
       token: 'token',
       bot,
-      deps: { appendJsonl, appendDailyNote, runPrime, loadFamilyConfig },
+      deps: { appendJsonl, appendScopedDailyNote: appendDailyNote, runPrime, loadFamilyConfig },
     });
 
     const reply = vi.fn().mockResolvedValue(undefined);
@@ -143,7 +144,7 @@ describe('telegram adapter', () => {
     createTelegramAdapter({
       token: 'token',
       bot,
-      deps: { appendJsonl, appendDailyNote, runPrime, loadFamilyConfig },
+      deps: { appendJsonl, appendScopedDailyNote: appendDailyNote, runPrime, loadFamilyConfig },
     });
 
     const reply = vi.fn().mockResolvedValue(undefined);

--- a/src/memory/memoryFiles.ts
+++ b/src/memory/memoryFiles.ts
@@ -19,7 +19,7 @@ async function safeRead(path: string): Promise<string> {
   return await readFile(path, 'utf8');
 }
 
-export async function loadMarkdownContextFiles(paths: MemoryPaths) {
+async function loadMarkdownContextFiles(paths: MemoryPaths) {
   const soul = await safeRead(join(paths.rootDir, 'SOUL.md'));
   const user = await safeRead(join(paths.rootDir, 'USER.md'));
   const longTerm = await safeRead(join(paths.rootDir, 'MEMORY.md'));

--- a/src/memory/scopedMemory.test.ts
+++ b/src/memory/scopedMemory.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import {
+  appendScopedDailyNote,
+  getScopedDailyPath,
+  getScopedLongTermPath,
+} from './scopedMemory.js';
+
+describe('scopedMemory', () => {
+  it('stores memory under memory/scopes/<hash>/...', async () => {
+    const rootDir = await mkdtemp(path.join(tmpdir(), 'scoped-memory-'));
+    const scopeId = 'telegram:dm:wags';
+
+    const longTerm = getScopedLongTermPath({ rootDir, scopeId });
+    const daily = getScopedDailyPath({ rootDir, scopeId }, new Date('2026-02-03T00:00:00Z'));
+
+    expect(longTerm).toContain(path.join(rootDir, 'memory', 'scopes'));
+    expect(daily).toContain(path.join(rootDir, 'memory', 'scopes'));
+    expect(daily).toContain('2026-02-03.md');
+  });
+
+  it('writes a header once and appends bullets', async () => {
+    const rootDir = await mkdtemp(path.join(tmpdir(), 'scoped-memory-'));
+    const scopeId = 'telegram:dm:wags';
+
+    const date = new Date('2026-02-03T12:00:00Z');
+
+    const p1 = await appendScopedDailyNote({ rootDir, scopeId }, 'first', date);
+    const p2 = await appendScopedDailyNote({ rootDir, scopeId }, '- second', date);
+
+    expect(p1).toBe(p2);
+
+    const contents = await readFile(p1, 'utf8');
+    expect(contents).toContain('# 2026-02-03');
+    expect(contents).toContain('- first');
+    expect(contents).toContain('- second');
+
+    // Header appears once.
+    expect(contents.match(/# 2026-02-03/g)?.length).toBe(1);
+  });
+});

--- a/src/memory/scopedMemory.ts
+++ b/src/memory/scopedMemory.ts
@@ -1,0 +1,84 @@
+import { appendFile, mkdir, readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { hashSessionId } from '../sessions/sessionHash.js';
+
+export type ScopedMemoryPaths = {
+  rootDir: string;
+  scopeId: string;
+};
+
+function isoDate(d = new Date()) {
+  return d.toISOString().slice(0, 10);
+}
+
+function sanitize(text: string): string {
+  // Very small safety net: avoid accidentally persisting obvious secrets.
+  return text
+    .replace(/\bsk-[A-Za-z0-9_-]{10,}\b/g, '[REDACTED_OPENAI_KEY]')
+    .replace(/\b\d{9,}:[A-Za-z0-9_-]{10,}\b/g, '[REDACTED_TELEGRAM_TOKEN]');
+}
+
+function scopeDir(paths: ScopedMemoryPaths): string {
+  const hashed = hashSessionId(paths.scopeId);
+  return join(paths.rootDir, 'memory', 'scopes', hashed);
+}
+
+export function getScopedLongTermPath(paths: ScopedMemoryPaths): string {
+  return join(scopeDir(paths), 'MEMORY.md');
+}
+
+export function getScopedDailyPath(paths: ScopedMemoryPaths, date = new Date()): string {
+  return join(scopeDir(paths), `${isoDate(date)}.md`);
+}
+
+async function safeRead(path: string): Promise<string> {
+  if (!existsSync(path)) return '';
+  return await readFile(path, 'utf8');
+}
+
+export async function loadScopedContextFiles(paths: ScopedMemoryPaths) {
+  const soul = await safeRead(join(paths.rootDir, 'SOUL.md'));
+  const user = await safeRead(join(paths.rootDir, 'USER.md'));
+
+  const longTermPath = getScopedLongTermPath(paths);
+  const todayPath = getScopedDailyPath(paths, new Date());
+  const yesterdayPath = getScopedDailyPath(
+    paths,
+    new Date(Date.now() - 24 * 60 * 60 * 1000),
+  );
+
+  const longTerm = await safeRead(longTermPath);
+  const today = await safeRead(todayPath);
+  const yesterday = await safeRead(yesterdayPath);
+
+  return {
+    soul,
+    user,
+    longTerm,
+    today,
+    yesterday,
+    longTermPath,
+    todayPath,
+  };
+}
+
+export async function appendScopedDailyNote(
+  paths: ScopedMemoryPaths,
+  note: string,
+  date = new Date(),
+) {
+  const path = getScopedDailyPath(paths, date);
+  await mkdir(scopeDir(paths), { recursive: true });
+
+  const header = `# ${isoDate(date)}\n\n`;
+  if (!existsSync(path)) {
+    await appendFile(path, header, 'utf8');
+  }
+
+  const clean = sanitize(note.trim());
+  const line = clean.startsWith('-') ? clean : `- ${clean}`;
+  await appendFile(path, line + '\n', 'utf8');
+
+  return path;
+}


### PR DESCRIPTION
Starts the next phase (memory distillation) by making memory files *scope-aware*.

Why:
- We already scope sessions/transcripts by scopeId.
- Memory files must follow the same boundary (DM vs parents group) to prevent leakage.

Changes:
- New src/memory/scopedMemory.ts
  - stores memory under HALO_HOME/memory/scopes/<sha256(scopeId)>/
  - per-scope MEMORY.md + daily YYYY-MM-DD.md
  - includes safe redaction (OpenAI key, Telegram token)
- Prime now loads context from scoped memory and remember_daily writes to scoped daily memory.
- Telegram adapter now passes rootDir into Prime and writes daily notes to scoped memory.
- Type safety: guard for policy.allow but missing scopeId.
- Knip: stop exporting unused loadMarkdownContextFiles.

Tests:
- Added scopedMemory tests.
- Updated telegram bot tests.

Follow-ups (next in this phase):
- Memory distiller: promote durable facts to per-scope MEMORY.md and keep temporals in daily.
- Tight boundary tests: ensure DM facts never appear in parents-group context.
