### PR TITLE
feat: deterministic memory distiller (rules-based)

### DIFF
--- a/src/memory/distiller.test.ts
+++ b/src/memory/distiller.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentInputItem } from '@openai/agents';
+
+import { distillMemoryFromItems } from './distiller.js';
+
+const user = (text: string): AgentInputItem => ({
+  type: 'message',
+  role: 'user',
+  content: [{ type: 'input_text', text }],
+});
+
+const assistant = (text: string): AgentInputItem => ({
+  type: 'message',
+  role: 'assistant',
+  content: [{ type: 'output_text', text }],
+} as any);
+
+describe('distiller (deterministic)', () => {
+  it('extracts explicit remember/note lines as durable facts', () => {
+    const out = distillMemoryFromItems([
+      user('remember: I like black coffee'),
+      user('note - preferred language is TypeScript'),
+      assistant('ok'),
+    ]);
+
+    expect(out.durableFacts).toEqual([
+      'I like black coffee',
+      'preferred language is TypeScript',
+    ]);
+    expect(out.temporalNotes).toEqual([]);
+  });
+
+  it('extracts simple “my X is Y” into key/value durable facts', () => {
+    const out = distillMemoryFromItems([
+      user('my timezone is Asia/Calcutta'),
+      user('my favorite editor is VS Code'),
+    ]);
+
+    expect(out.durableFacts).toEqual([
+      'timezone: Asia/Calcutta',
+      'favorite editor: VS Code',
+    ]);
+  });
+
+  it('dedupes identical facts and keeps other content as temporal notes', () => {
+    const out = distillMemoryFromItems([
+      user('remember: I like black coffee'),
+      user('remember: I like black coffee'),
+      user('today I feel great'),
+      user('today I feel great'),
+    ]);
+
+    expect(out.durableFacts).toEqual(['I like black coffee']);
+    expect(out.temporalNotes).toEqual(['today I feel great']);
+  });
+});

--- a/src/memory/distiller.ts
+++ b/src/memory/distiller.ts
@@ -1,0 +1,79 @@
+import type { AgentInputItem } from '@openai/agents';
+
+export type DistilledMemory = {
+  durableFacts: string[];
+  temporalNotes: string[];
+};
+
+const normalizeLine = (line: string) => line.trim().replace(/\s+/g, ' ');
+
+function uniq(lines: string[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const line of lines) {
+    const key = normalizeLine(line);
+    if (!key) continue;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(line.trim());
+  }
+  return out;
+}
+
+function extractUserText(item: AgentInputItem): string[] {
+  if (item.type !== 'message') return [];
+  if (item.role !== 'user') return [];
+
+  const parts = item.content ?? [];
+  const texts: string[] = [];
+  for (const p of parts as any[]) {
+    if (typeof p === 'string') {
+      // Some SDK types allow plain strings in content arrays.
+      texts.push(p);
+      continue;
+    }
+    if (p && typeof p === 'object' && p.type === 'input_text' && typeof p.text === 'string') {
+      texts.push(p.text);
+    }
+  }
+  return texts;
+}
+
+// Very small, deterministic heuristic set (no model calls).
+// The goal is: start safe, be testable, and avoid cross-scope leakage.
+export function distillMemoryFromItems(items: AgentInputItem[]): DistilledMemory {
+  const durableFacts: string[] = [];
+  const temporalNotes: string[] = [];
+
+  for (const item of items) {
+    for (const text of extractUserText(item)) {
+      const t = text.trim();
+      if (!t) continue;
+
+      // Durable facts: explicit “remember” / “my … is …” style.
+      // Keep it conservative and short.
+      const rememberMatch = t.match(/^(remember|note)\b[:\s-]*(.+)$/i);
+      if (rememberMatch?.[2]) {
+        durableFacts.push(rememberMatch[2].trim());
+        continue;
+      }
+
+      const myIsMatch = t.match(/^my\s+([a-z][a-z0-9_\s-]{0,40})\s+is\s+(.{1,80})$/i);
+      if (myIsMatch) {
+        const key = myIsMatch[1].trim();
+        const val = myIsMatch[2].trim();
+        durableFacts.push(`${key}: ${val}`);
+        continue;
+      }
+
+      // Temporal notes: small check-ins (today/tomorrow) or anything else.
+      // Keep for daily log by default.
+      temporalNotes.push(t);
+    }
+  }
+
+  return {
+    durableFacts: uniq(durableFacts),
+    temporalNotes: uniq(temporalNotes),
+  };
+}


### PR DESCRIPTION
Implements the first piece of milestone #29 (Memory distillation): a deterministic, offline distiller.

- Adds src/memory/distiller.ts
  - Extracts durable facts conservatively from user messages:
    - `remember:` / `note:` prefix → durable fact
    - `my <thing> is <value>` → durable key/value fact
  - Everything else is treated as a temporal note (for the daily log)
  - Dedupe + normalization; no network calls

- Adds tests in src/memory/distiller.test.ts

Follow-up PRs will wire this into scoped files and add strict DM vs parents-group boundary tests.

Closes: #31
Part of: #29
