### PR TITLE
feat: wire deterministic distillation trigger (flagged)

### DIFF
--- a/src/memory/distillationRunner.ts
+++ b/src/memory/distillationRunner.ts
@@ -1,0 +1,42 @@
+import type { AgentInputItem } from '@openai/agents';
+
+import { distillMemoryFromItems } from './distiller.js';
+import { appendScopedDailyNote } from './scopedMemory.js';
+import { appendScopedLongTermFacts } from './scopedLongTerm.js';
+
+export type RunDistillationOptions = {
+  rootDir: string;
+  scopeId: string;
+  items: AgentInputItem[];
+};
+
+/**
+ * Run deterministic distillation and write back to per-scope memory files.
+ *
+ * - durableFacts -> HALO_HOME/memory/scopes/<hash>/MEMORY.md
+ * - temporalNotes -> HALO_HOME/memory/scopes/<hash>/YYYY-MM-DD.md
+ */
+export async function runDeterministicDistillation(
+  opts: RunDistillationOptions,
+): Promise<{ durableFacts: number; temporalNotes: number }> {
+  const distilled = distillMemoryFromItems(opts.items);
+
+  if (distilled.durableFacts.length > 0) {
+    await appendScopedLongTermFacts(
+      { rootDir: opts.rootDir, scopeId: opts.scopeId },
+      distilled.durableFacts,
+    );
+  }
+
+  for (const note of distilled.temporalNotes) {
+    await appendScopedDailyNote(
+      { rootDir: opts.rootDir, scopeId: opts.scopeId },
+      note,
+    );
+  }
+
+  return {
+    durableFacts: distilled.durableFacts.length,
+    temporalNotes: distilled.temporalNotes.length,
+  };
+}

--- a/src/memory/scopedLongTerm.test.ts
+++ b/src/memory/scopedLongTerm.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { appendScopedLongTermFacts } from './scopedLongTerm.js';
+import { getScopedLongTermPath } from './scopedMemory.js';
+
+describe('scopedLongTerm', () => {
+  it('creates MEMORY.md and appends bullets, deduping', async () => {
+    const rootDir = await mkdtemp(path.join(tmpdir(), 'halo-longterm-'));
+    const scopeId = 'telegram:dm:wags';
+
+    const p1 = await appendScopedLongTermFacts(
+      { rootDir, scopeId },
+      ['I like coffee', 'I like coffee', 'Timezone: Asia/Calcutta'],
+    );
+
+    expect(p1).toBe(getScopedLongTermPath({ rootDir, scopeId }));
+
+    const content = await readFile(p1, 'utf8');
+    expect(content).toContain('# MEMORY');
+    expect(content).toContain('- I like coffee');
+    expect(content).toContain('- Timezone: Asia/Calcutta');
+
+    // Ensure only one coffee line.
+    expect(content.match(/I like coffee/g)?.length).toBe(1);
+  });
+});

--- a/src/memory/scopedLongTerm.ts
+++ b/src/memory/scopedLongTerm.ts
@@ -1,0 +1,46 @@
+import { appendFile, mkdir, readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+
+import { getScopedLongTermPath, type ScopedMemoryPaths } from './scopedMemory.js';
+
+function normalize(line: string): string {
+  return line.trim().replace(/^[-*]\s+/, '').trim().toLowerCase();
+}
+
+/**
+ * Append durable facts to the per-scope MEMORY.md, deduping by normalized content.
+ *
+ * Format is intentionally simple (bullets) so it stays deterministic and human-editable.
+ */
+export async function appendScopedLongTermFacts(
+  paths: ScopedMemoryPaths,
+  facts: string[],
+): Promise<string> {
+  const filePath = getScopedLongTermPath(paths);
+
+  await mkdir(filePath.split('/').slice(0, -1).join('/'), { recursive: true });
+
+  const existing = existsSync(filePath) ? await readFile(filePath, 'utf8') : '';
+  const existingLines = existing.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  const seen = new Set(existingLines.map(normalize));
+
+  const toAppend: string[] = [];
+  for (const fact of facts) {
+    const clean = fact.trim();
+    if (!clean) continue;
+    const key = normalize(clean);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    toAppend.push(`- ${clean}`);
+  }
+
+  if (!existsSync(filePath)) {
+    await appendFile(filePath, '# MEMORY\n\n', 'utf8');
+  }
+
+  if (toAppend.length > 0) {
+    await appendFile(filePath, toAppend.join('\n') + '\n', 'utf8');
+  }
+
+  return filePath;
+}

--- a/src/sessions/distillingTranscriptSession.test.ts
+++ b/src/sessions/distillingTranscriptSession.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { SessionStore } from './sessionStore.js';
+import { getScopedLongTermPath } from '../memory/scopedMemory.js';
+import type { AgentInputItem } from '@openai/agents';
+
+const userMessage = (text: string) =>
+  ({
+    type: 'message',
+    role: 'user',
+    content: [{ type: 'input_text', text }],
+  }) satisfies AgentInputItem;
+
+describe('distillation trigger wiring', () => {
+  it('runs deterministic distillation and writes scoped MEMORY.md when enabled', async () => {
+    const rootDir = await mkdtemp(path.join(tmpdir(), 'halo-distill-'));
+
+    const store = new SessionStore({
+      baseDir: path.join(rootDir, 'sessions'),
+      transcriptsDir: path.join(rootDir, 'transcripts'),
+      compactionEnabled: false,
+      distillationEnabled: true,
+      distillationEveryNItems: 1,
+      distillationMaxItems: 50,
+      rootDir,
+    });
+
+    const scopeId = 'telegram:dm:wags';
+    const session = store.getOrCreate(scopeId);
+
+    await session.addItems([userMessage('remember: I like black coffee')]);
+
+    // Wait a tiny bit for the async distillation chain to run.
+    await new Promise((r) => setTimeout(r, 20));
+
+    const memPath = getScopedLongTermPath({ rootDir, scopeId });
+    const content = await readFile(memPath, 'utf8');
+    expect(content).toContain('I like black coffee');
+  });
+});

--- a/src/sessions/distillingTranscriptSession.ts
+++ b/src/sessions/distillingTranscriptSession.ts
@@ -1,0 +1,140 @@
+import type { AgentInputItem, Session } from '@openai/agents';
+
+import { TranscriptStore } from './transcriptStore.js';
+import { isOpenAIResponsesCompactionAwareSession } from '@openai/agents';
+import type {
+  OpenAIResponsesCompactionArgs,
+  OpenAIResponsesCompactionAwareSession,
+  OpenAIResponsesCompactionResult,
+} from '@openai/agents';
+import { runDeterministicDistillation } from '../memory/distillationRunner.js';
+
+export type DistillationConfig = {
+  enabled: boolean;
+  /** Trigger distillation after this many appended items. */
+  everyNItems: number;
+  /** How many transcript items to consider when distilling. */
+  maxItems: number;
+  /** Root dir for scoped memory writes (HALO_HOME). */
+  rootDir: string;
+};
+
+class DistillingTranscriptSession implements Session {
+  protected readonly session: Session;
+  protected readonly transcript: TranscriptStore;
+  protected readonly scopeId: string;
+  protected readonly distill: DistillationConfig;
+
+  private pending = 0;
+  private running: Promise<void> | null = null;
+
+  constructor(options: {
+    session: Session;
+    transcript: TranscriptStore;
+    scopeId: string;
+    distill: DistillationConfig;
+  }) {
+    this.session = options.session;
+    this.transcript = options.transcript;
+    this.scopeId = options.scopeId;
+    this.distill = options.distill;
+  }
+
+  async getSessionId(): Promise<string> {
+    return this.session.getSessionId();
+  }
+
+  async getItems(limit?: number): Promise<AgentInputItem[]> {
+    return this.session.getItems(limit);
+  }
+
+  async addItems(items: AgentInputItem[]): Promise<void> {
+    if (items.length === 0) return;
+
+    // Append to transcript first so the source-of-truth is durable even if derived state fails.
+    await this.transcript.appendItems(items);
+    await this.session.addItems(items);
+
+    if (!this.distill.enabled) return;
+
+    this.pending += items.length;
+    if (this.pending < this.distill.everyNItems) return;
+
+    // Reset pending first to avoid repeated triggers if we crash.
+    this.pending = 0;
+
+    // Fire-and-forget (but serialized) distillation.
+    // We don't want to block the user reply on distillation.
+    this.running = (this.running ?? Promise.resolve())
+      .then(async () => {
+        const all = await this.transcript.getItems();
+        const slice = all.slice(Math.max(0, all.length - this.distill.maxItems));
+        await runDeterministicDistillation({
+          rootDir: this.distill.rootDir,
+          scopeId: this.scopeId,
+          items: slice,
+        });
+      })
+      .catch((err) => {
+        // Fail-safe: never break the chat loop because distillation failed.
+        // We don't have a structured logger at this layer; callers can monitor gateway event logs.
+        console.error('halo: distillation failed', {
+          scopeId: this.scopeId,
+          error: err instanceof Error ? { name: err.name, message: err.message, stack: err.stack } : String(err),
+        });
+      })
+      .finally(() => {
+        // Keep chain alive.
+        if (this.running) this.running = null;
+      });
+  }
+
+  async popItem(): Promise<AgentInputItem | undefined> {
+    return this.session.popItem();
+  }
+
+  async clearSession(): Promise<void> {
+    await this.session.clearSession();
+  }
+}
+
+class DistillingTranscriptCompactionSession
+  extends DistillingTranscriptSession
+  implements OpenAIResponsesCompactionAwareSession
+{
+  private readonly compactionSession: OpenAIResponsesCompactionAwareSession;
+
+  constructor(options: {
+    session: OpenAIResponsesCompactionAwareSession;
+    transcript: TranscriptStore;
+    scopeId: string;
+    distill: DistillationConfig;
+  }) {
+    super(options);
+    this.compactionSession = options.session;
+  }
+
+  runCompaction(
+    args?: OpenAIResponsesCompactionArgs,
+  ): Promise<OpenAIResponsesCompactionResult | null> | OpenAIResponsesCompactionResult | null {
+    return this.compactionSession.runCompaction(args);
+  }
+}
+
+export function wrapWithTranscriptAndDistillation(
+  session: Session,
+  transcript: TranscriptStore,
+  scopeId: string,
+  distill: DistillationConfig,
+): Session {
+  if (isOpenAIResponsesCompactionAwareSession(session)) {
+    return new DistillingTranscriptCompactionSession({
+      session,
+      transcript,
+      scopeId,
+      distill,
+    });
+  }
+
+  return new DistillingTranscriptSession({ session, transcript, scopeId, distill });
+}


### PR DESCRIPTION
Wires deterministic (offline) memory distillation into the session pipeline behind a feature flag.

- Adds per-scope long-term MEMORY.md writeback with dedupe:
  - src/memory/scopedLongTerm.ts (+ tests)
- Adds distillation runner that writes:
  - durable facts -> scoped MEMORY.md
  - temporals -> scoped daily log
- Adds a distilling transcript session wrapper that triggers asynchronously after N appended items
- SessionStore now supports distillation options:
  - distillationEnabled (default false)
  - distillationEveryNItems (default 20)
  - distillationMaxItems (default 200)
  - rootDir (HALO_HOME)
  - env flag: HALO_DISTILLATION_ENABLED=true

Fail-safe:
- Distillation errors are caught and logged to console; they do not break the chat loop.

Tests:
- New test asserting that with distillation enabled, a `remember:` message creates scoped MEMORY.md.

Closes: #33
Part of: #29
