### PR TITLE
feat: HALO_HOME/config.json (canonical config)

### DIFF
--- a/config/halo.example.json
+++ b/config/halo.example.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": 1,
+  "gateway": {
+    "host": "127.0.0.1",
+    "port": 8787
+  },
+  "features": {
+    "compactionEnabled": false,
+    "distillationEnabled": false
+  },
+  "memory": {
+    "distillationEveryNItems": 20,
+    "distillationMaxItems": 200
+  },
+  "family": {
+    "schemaVersion": 1,
+    "familyId": "default",
+    "members": [
+      {
+        "memberId": "wags",
+        "displayName": "Wags",
+        "role": "parent",
+        "telegramUserIds": [889348242]
+      }
+    ],
+    "parentsGroup": {
+      "telegramChatId": null
+    }
+  }
+}

--- a/docs/04-config.md
+++ b/docs/04-config.md
@@ -1,14 +1,16 @@
 # Configuration
 
-This project is configured via local JSON files.
+This project is configured via a single JSON file.
 
-- Example configs are committed under `config/*.example.json`.
-- Real configs live under `HALO_HOME/config/*.json` and are **gitignored** (defaults to `~/.halo`).
+- Example config is committed under `config/halo.example.json`.
+- Real config lives at: `HALO_HOME/config.json` (defaults to `~/.halo/config.json`).
 
 ## Files
 
-- `config/family.example.json` → `HALO_HOME/config/family.json`
-- `config/nodes.example.json` → `HALO_HOME/config/nodes.json`
+- `config/halo.example.json` → `HALO_HOME/config.json`
+
+Notes:
+- `TELEGRAM_BOT_TOKEN` stays in the environment (don’t put secrets in config.json).
 
 ## Principles
 

--- a/src/gateway/start.ts
+++ b/src/gateway/start.ts
@@ -4,6 +4,7 @@ import process from 'node:process';
 import path from 'node:path';
 import { startGateway } from './runtime.js';
 import { getHaloHome } from '../runtime/haloHome.js';
+import { loadHaloConfig } from '../runtime/haloConfig.js';
 
 const token = process.env.TELEGRAM_BOT_TOKEN;
 if (!token) {
@@ -13,15 +14,16 @@ if (!token) {
 // Durable runtime state should live outside the repo.
 const haloHome = getHaloHome(process.env);
 
+const haloConfig = await loadHaloConfig(process.env);
+
 // Allow overrides, but default to HALO_HOME/logs.
 const logDir = process.env.LOG_DIR || path.join(haloHome, 'logs');
 
-const adminHost = process.env.GATEWAY_HOST || '127.0.0.1';
-const adminPortRaw = process.env.GATEWAY_PORT || '8787';
-const adminPort = Number.parseInt(adminPortRaw, 10);
+const adminHost = haloConfig.gateway.host;
+const adminPort = haloConfig.gateway.port;
 
 if (!Number.isFinite(adminPort)) {
-  throw new Error('Invalid GATEWAY_PORT in environment');
+  throw new Error('Invalid gateway.port in HALO_HOME/config.json');
 }
 
 console.log('halo (gateway) starting…');

--- a/src/runtime/familyConfig.ts
+++ b/src/runtime/familyConfig.ts
@@ -22,7 +22,7 @@ const ParentsGroupSchema = z
   })
   .strict();
 
-export const FamilyConfigSchema = z
+export const FAMILY_CONFIG_SCHEMA = z
   .object({
     schemaVersion: z.literal(FAMILY_SCHEMA_VERSION),
     familyId: z.string().min(1),
@@ -31,7 +31,7 @@ export const FamilyConfigSchema = z
   })
   .strict();
 
-export type FamilyConfig = z.infer<typeof FamilyConfigSchema>;
+export type FamilyConfig = z.infer<typeof FAMILY_CONFIG_SCHEMA>;
 
 export type FamilyConfigLoadOptions = {
   env?: NodeJS.ProcessEnv;
@@ -59,7 +59,7 @@ function parseFamilyConfig(
   data: unknown,
   sourcePath = 'family config',
 ): FamilyConfig {
-  const parsed = FamilyConfigSchema.safeParse(data);
+  const parsed = FAMILY_CONFIG_SCHEMA.safeParse(data);
   if (parsed.success) return parsed.data;
 
   const details = formatZodIssues(parsed.error);

--- a/src/runtime/haloConfig.ts
+++ b/src/runtime/haloConfig.ts
@@ -1,0 +1,80 @@
+import { readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { z } from 'zod';
+
+import { getHaloHome } from './haloHome.js';
+import { FAMILY_CONFIG_SCHEMA } from './familyConfig.js';
+
+const HALO_CONFIG_SCHEMA_VERSION = 1;
+
+const HALO_CONFIG_SCHEMA = z.object({
+  schemaVersion: z.literal(HALO_CONFIG_SCHEMA_VERSION),
+
+  gateway: z
+    .object({
+      host: z.string().default('127.0.0.1'),
+      port: z.number().int().positive().default(8787),
+    })
+    .default({ host: '127.0.0.1', port: 8787 }),
+
+  features: z
+    .object({
+      compactionEnabled: z.boolean().default(false),
+      distillationEnabled: z.boolean().default(false),
+    })
+    .default({ compactionEnabled: false, distillationEnabled: false }),
+
+  memory: z
+    .object({
+      distillationEveryNItems: z.number().int().positive().default(20),
+      distillationMaxItems: z.number().int().positive().default(200),
+    })
+    .default({ distillationEveryNItems: 20, distillationMaxItems: 200 }),
+
+  family: FAMILY_CONFIG_SCHEMA,
+});
+
+export type HaloConfig = z.infer<typeof HALO_CONFIG_SCHEMA>;
+
+function getHaloConfigPath(env: NodeJS.ProcessEnv): string {
+  const haloHome = getHaloHome(env);
+  return path.join(haloHome, 'config.json');
+}
+
+export async function loadHaloConfig(env: NodeJS.ProcessEnv): Promise<HaloConfig> {
+  const configPath = getHaloConfigPath(env);
+
+  if (!existsSync(configPath)) {
+    throw new Error(
+      `Missing halo config at ${configPath}. Copy config/halo.example.json to HALO_HOME/config.json and edit it.`,
+    );
+  }
+
+  const raw = await readFile(configPath, 'utf8');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`Invalid JSON in ${configPath}: ${(err as Error).message}`);
+  }
+
+  const res = HALO_CONFIG_SCHEMA.safeParse(parsed);
+  if (!res.success) {
+    throw new Error(
+      `Invalid halo config at ${configPath}: ${res.error.message}`,
+    );
+  }
+
+  // Env overrides (keep minimal; tokens remain env-only).
+  const host = env.GATEWAY_HOST;
+  const portRaw = env.GATEWAY_PORT;
+
+  return {
+    ...res.data,
+    gateway: {
+      host: host ?? res.data.gateway.host,
+      port: portRaw ? Number.parseInt(portRaw, 10) : res.data.gateway.port,
+    },
+  };
+}


### PR DESCRIPTION
Introduces a single canonical HALO_HOME/config.json for runtime settings (M6).

- Adds config/halo.example.json
- Adds src/runtime/haloConfig.ts (Zod-validated loader)
- Gateway start now loads HALO_HOME/config.json and uses it for gateway host/port
- Updates docs/04-config.md to reflect config.json as the primary configuration file

Notes
- TELEGRAM_BOT_TOKEN remains env-only (no secrets in config.json)
- Family config is now nested under config.json (same schema as before)

Part of: #37
