### PR TITLE
feat: apply config.json to session store

### DIFF
--- a/src/gateway/start.ts
+++ b/src/gateway/start.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { startGateway } from './runtime.js';
 import { getHaloHome } from '../runtime/haloHome.js';
 import { loadHaloConfig } from '../runtime/haloConfig.js';
+import { SessionStore } from '../sessions/sessionStore.js';
 
 const token = process.env.TELEGRAM_BOT_TOKEN;
 if (!token) {
@@ -22,6 +23,17 @@ const logDir = process.env.LOG_DIR || path.join(haloHome, 'logs');
 const adminHost = haloConfig.gateway.host;
 const adminPort = haloConfig.gateway.port;
 
+const sessionStore = new SessionStore({
+  // Canonical settings come from HALO_HOME/config.json
+  compactionEnabled: haloConfig.features.compactionEnabled,
+  distillationEnabled: haloConfig.features.distillationEnabled,
+  distillationEveryNItems: haloConfig.memory.distillationEveryNItems,
+  distillationMaxItems: haloConfig.memory.distillationMaxItems,
+  rootDir: haloHome,
+  baseDir: path.join(haloHome, 'sessions'),
+  transcriptsDir: path.join(haloHome, 'transcripts'),
+});
+
 if (!Number.isFinite(adminPort)) {
   throw new Error('Invalid gateway.port in HALO_HOME/config.json');
 }
@@ -38,4 +50,5 @@ await startGateway({
     port: adminPort,
     haloHome,
   },
+  sessionStore,
 });

--- a/src/prime/prime.ts
+++ b/src/prime/prime.ts
@@ -2,7 +2,7 @@ import { Agent, run, tool } from '@openai/agents';
 import { z } from 'zod';
 import process from 'node:process';
 import { appendScopedDailyNote, loadScopedContextFiles } from '../memory/scopedMemory.js';
-import { defaultSessionStore } from '../sessions/sessionStore.js';
+import { defaultSessionStore, type SessionStore } from '../sessions/sessionStore.js';
 
 export type PrimeRunOptions = {
   /** Stable identifier for the current speaker (Telegram user id, etc.) */
@@ -11,6 +11,8 @@ export type PrimeRunOptions = {
   scopeId?: string;
   /** Root directory for durable runtime state (HALO_HOME). Defaults to process.cwd() for CLI/dev. */
   rootDir?: string;
+  /** Optional session store override (used by gateway to apply config.json). */
+  sessionStore?: SessionStore;
   channel?: 'telegram' | 'cli';
 };
 
@@ -78,7 +80,8 @@ export async function runPrime(input: string, opts: PrimeRunOptions = {}) {
 
   const agent = await makePrimeAgent({ rootDir, scopeId });
 
-  const session = defaultSessionStore.getOrCreate(scopeId);
+  const store = opts.sessionStore ?? defaultSessionStore;
+  const session = store.getOrCreate(scopeId);
 
   const result = await run(agent, input, {
     session,


### PR DESCRIPTION
Wires HALO_HOME/config.json settings into the runtime session store.

- Gateway start now constructs a SessionStore using config.json:
  - features.compactionEnabled
  - features.distillationEnabled
  - memory.distillationEveryNItems
  - memory.distillationMaxItems
  - HALO_HOME root dirs for sessions/transcripts
- Gateway passes that SessionStore through to:
  - admin server (sessions endpoints reflect configured behavior)
  - telegram adapter via runPrime wrapper, so Prime uses the configured store

Notes
- CLI remains unchanged (still uses the default store); gateway is the canonical runtime.

Part of: #37
