### PR TITLE
feat: include config snapshot in gateway /status

### DIFF
--- a/src/gateway/admin.ts
+++ b/src/gateway/admin.ts
@@ -21,6 +21,21 @@ type GatewayStatus = {
     host: string;
     port: number;
   };
+  config?: {
+    schemaVersion?: number;
+    gateway?: {
+      host?: string;
+      port?: number;
+    };
+    features?: {
+      compactionEnabled?: boolean;
+      distillationEnabled?: boolean;
+    };
+    memory?: {
+      distillationEveryNItems?: number;
+      distillationMaxItems?: number;
+    };
+  };
 };
 
 type PolicyScopeStatus = {
@@ -44,6 +59,7 @@ export type StatusContext = {
   version: string | null;
   haloHome: HaloHomePaths;
   sessionStore: SessionStore;
+  config?: GatewayStatus['config'];
   now?: () => number;
 };
 
@@ -154,6 +170,7 @@ export type AdminServerOptions = {
   haloHome: string;
   version: string | null;
   sessionStore: SessionStore;
+  config?: GatewayStatus['config'];
   startedAtMs?: number;
   now?: () => number;
 };
@@ -200,6 +217,7 @@ function createStatusPayload(context: StatusContext): GatewayStatus {
       host: context.host,
       port: context.port,
     },
+    config: context.config,
   };
 }
 
@@ -357,6 +375,7 @@ export async function startAdminServer(options: AdminServerOptions): Promise<Adm
     version: options.version,
     haloHome: buildHaloHomePaths(options.haloHome),
     sessionStore: options.sessionStore,
+    config: options.config,
     now: options.now,
   };
 

--- a/src/gateway/runtime.ts
+++ b/src/gateway/runtime.ts
@@ -16,6 +16,12 @@ export type GatewayOptions = {
     startedAtMs?: number;
   };
   sessionStore?: SessionStore;
+  config?: {
+    schemaVersion?: number;
+    gateway?: { host?: string; port?: number };
+    features?: { compactionEnabled?: boolean; distillationEnabled?: boolean };
+    memory?: { distillationEveryNItems?: number; distillationMaxItems?: number };
+  };
 };
 
 export const DEFAULT_GATEWAY_HOST = '127.0.0.1';
@@ -73,6 +79,7 @@ export async function startGateway(options: GatewayOptions) {
     haloHome,
     version,
     sessionStore,
+    config: options.config,
     startedAtMs: options.admin?.startedAtMs,
   });
 

--- a/src/gateway/start.ts
+++ b/src/gateway/start.ts
@@ -51,4 +51,10 @@ await startGateway({
     haloHome,
   },
   sessionStore,
+  config: {
+    schemaVersion: haloConfig.schemaVersion,
+    gateway: haloConfig.gateway,
+    features: haloConfig.features,
+    memory: haloConfig.memory,
+  },
 });


### PR DESCRIPTION
Adds a sanitized config snapshot to the gateway /status payload for easier debugging.

- /status now includes a `config` object (schemaVersion, gateway, features, memory)
- Gateway start passes the loaded config.json values through to the admin server context

No secrets are included (TELEGRAM_BOT_TOKEN remains env-only).

Part of: #37
