### PR TITLE
chore: add local end-to-end smoke test

### DIFF
--- a/docs/10-smoke-tests.md
+++ b/docs/10-smoke-tests.md
@@ -1,0 +1,24 @@
+# Smoke tests
+
+We keep a fast, local end-to-end smoke test to catch wiring regressions across:
+- gateway admin server
+- telegram adapter
+- sessions/transcripts
+- scoped memory + distillation
+
+## Run
+
+```bash
+pnpm smoke:e2e
+# or
+./scripts/smoke-e2e.sh
+```
+
+Expected output:
+- prints `SMOKE_E2E_OK`
+- prints the temporary HALO_HOME used for the run
+
+## Notes
+
+- The smoke test uses a **fake Telegram bot** (no network calls).
+- Prime is stubbed to avoid model calls; it still appends a user item into the configured SessionStore so transcripts + distillation are exercised.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "check:dup": "jscpd --config jscpd.json",
     "check:todo": "tsx src/dev/todoCheck.ts",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "smoke:e2e": "tsx src/dev/smokeE2E.ts"
   },
   "keywords": [],
   "author": "",

--- a/scripts/smoke-e2e.sh
+++ b/scripts/smoke-e2e.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+pnpm -s smoke:e2e

--- a/src/dev/smokeE2E.ts
+++ b/src/dev/smokeE2E.ts
@@ -1,0 +1,201 @@
+import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import type { AgentInputItem } from '@openai/agents';
+
+import { createTelegramAdapter, type TelegramBotLike, type TelegramContext } from '../interfaces/telegram/bot.js';
+import { startAdminServer } from '../gateway/admin.js';
+import { hashSessionId } from '../sessions/sessionHash.js';
+import { SessionStore } from '../sessions/sessionStore.js';
+
+const userMessage = (text: string) =>
+  ({
+    type: 'message',
+    role: 'user',
+    content: [{ type: 'input_text', text }],
+  }) satisfies AgentInputItem;
+
+type HandlerBag = {
+  messageText?: (ctx: TelegramContext) => Promise<void> | void;
+  error?: (err: unknown) => Promise<void> | void;
+};
+
+type FakeBot = TelegramBotLike & {
+  handlers: HandlerBag;
+  start: () => Promise<void>;
+};
+
+const makeFakeBot = (): FakeBot => {
+  const handlers: HandlerBag = {};
+  return {
+    handlers,
+    on: (event, handler) => {
+      if (event === 'message:text') handlers.messageText = handler;
+    },
+    catch: (handler) => {
+      handlers.error = handler;
+    },
+    start: async () => {},
+  };
+};
+
+async function httpGetJson(url: string): Promise<unknown> {
+  const res = await fetch(url);
+  const text = await res.text();
+  if (!res.ok) throw new Error(`HTTP ${res.status}: ${text}`);
+  return JSON.parse(text) as unknown;
+}
+
+async function main() {
+  const haloHome = await mkdtemp(path.join(tmpdir(), 'halo-smoke-'));
+
+  // Minimal family config for policy.
+  await mkdir(path.join(haloHome, 'config'), { recursive: true });
+  await writeFile(
+    path.join(haloHome, 'config', 'family.json'),
+    JSON.stringify(
+      {
+        schemaVersion: 1,
+        familyId: 'default',
+        members: [
+          {
+            memberId: 'wags',
+            displayName: 'Wags',
+            role: 'parent',
+            telegramUserIds: [456],
+          },
+        ],
+        parentsGroup: { telegramChatId: null },
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  // Canonical config.json (required by gateway runtime).
+  await writeFile(
+    path.join(haloHome, 'config.json'),
+    JSON.stringify(
+      {
+        schemaVersion: 1,
+        gateway: { host: '127.0.0.1', port: 0 },
+        features: { compactionEnabled: false, distillationEnabled: true },
+        memory: { distillationEveryNItems: 1, distillationMaxItems: 50 },
+        family: {
+          schemaVersion: 1,
+          familyId: 'default',
+          members: [
+            {
+              memberId: 'wags',
+              displayName: 'Wags',
+              role: 'parent',
+              telegramUserIds: [456],
+            },
+          ],
+          parentsGroup: { telegramChatId: null },
+        },
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const store = new SessionStore({
+    baseDir: path.join(haloHome, 'sessions'),
+    transcriptsDir: path.join(haloHome, 'transcripts'),
+    rootDir: haloHome,
+    compactionEnabled: false,
+    distillationEnabled: true,
+    distillationEveryNItems: 1,
+    distillationMaxItems: 50,
+  });
+
+  // Start admin server on an ephemeral port.
+  const admin = await startAdminServer({
+    host: '127.0.0.1',
+    port: 0,
+    haloHome,
+    version: 'smoke',
+    sessionStore: store,
+    config: {
+      schemaVersion: 1,
+      gateway: { host: '127.0.0.1', port: 0 },
+      features: { compactionEnabled: false, distillationEnabled: true },
+      memory: { distillationEveryNItems: 1, distillationMaxItems: 50 },
+    },
+  });
+
+  const { port } = admin.context;
+
+  // Wire a telegram adapter with a fake bot.
+  const bot = makeFakeBot();
+
+  const adapter = createTelegramAdapter({
+    token: 'token',
+    bot,
+    logDir: path.join(haloHome, 'logs'),
+    rootDir: haloHome,
+    haloHome,
+    deps: {
+      // Stub Prime: just ensure we write a transcript item through the configured session.
+      runPrime: async (input, opts) => {
+        const scopeId = opts?.scopeId ?? 'telegram:dm:wags';
+        const session = store.getOrCreate(scopeId);
+        await session.addItems([userMessage(input)]);
+        return { finalOutput: 'smoke reply', raw: null as any };
+      },
+    },
+  });
+
+  const handler = bot.handlers.messageText;
+  if (!handler) throw new Error('smoke: telegram handler missing');
+
+  const replyCalls: string[] = [];
+  const ctx: TelegramContext = {
+    chat: { id: 1, type: 'private' },
+    message: { text: 'remember: I like black coffee', message_id: 1 },
+    from: { id: 456 },
+    reply: async (text) => {
+      replyCalls.push(text);
+    },
+  };
+
+  await handler(ctx);
+
+  if (replyCalls[0] !== 'smoke reply') {
+    throw new Error(`smoke: unexpected reply: ${replyCalls[0]}`);
+  }
+
+  // Verify transcript was written.
+  const scopeId = 'telegram:dm:wags';
+  const hashed = hashSessionId(scopeId);
+  const transcriptPath = path.join(haloHome, 'transcripts', `${hashed}.jsonl`);
+  const transcriptRaw = await readFile(transcriptPath, 'utf8');
+  if (!transcriptRaw.includes('black coffee')) {
+    throw new Error('smoke: transcript missing expected content');
+  }
+
+  // Verify distillation wrote to scoped long-term memory.
+  const memoryDir = path.join(haloHome, 'memory', 'scopes', hashed);
+  const memoryPath = path.join(memoryDir, 'MEMORY.md');
+  const memoryRaw = await readFile(memoryPath, 'utf8');
+  if (!memoryRaw.includes('black coffee')) {
+    throw new Error('smoke: MEMORY.md missing distilled fact');
+  }
+
+  // Verify /status includes config snapshot.
+  const status = (await httpGetJson(`http://127.0.0.1:${port}/status`)) as any;
+  if (!status?.config?.features || status.config.features.distillationEnabled !== true) {
+    throw new Error('smoke: /status config snapshot missing or incorrect');
+  }
+
+  await new Promise<void>((resolve) => admin.server.close(() => resolve()));
+
+  console.log('SMOKE_E2E_OK');
+  console.log(haloHome);
+}
+
+await main();


### PR DESCRIPTION
Adds a fast local end-to-end smoke test to catch wiring regressions.

- New: pnpm smoke:e2e (tsx src/dev/smokeE2E.ts)
- Script: scripts/smoke-e2e.sh
- Docs: docs/10-smoke-tests.md

What it covers (no network, no model calls):
- Starts admin server on an ephemeral port
- Runs telegram adapter with a fake bot
- Stubs Prime but still writes transcript items through SessionStore
- Verifies:
  - transcript JSONL written
  - scoped MEMORY.md contains distilled durable fact
  - /status includes config snapshot

This complements unit tests with a single-command sanity check.
