### PR TITLE
docs: note OpenAI docs MCP server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,3 +118,9 @@ Quality bar:
 ## Work in progress
 
 - Family-first policy + transcript admin tooling (iterating).
+
+## Docs MCP
+
+When working on OpenAI API / Agents SDK / Codex details, consult the OpenAI Developer Docs MCP server via Codex:
+- MCP name: `openaiDeveloperDocs`
+- URL: https://developers.openai.com/mcp


### PR DESCRIPTION
Adds a small note in AGENTS.md about configuring the OpenAI developer docs MCP server for Codex.

- Docs MCP URL: https://developers.openai.com/mcp
- MCP name: openaiDeveloperDocs

This makes it easy to reliably reference official docs during development.
