### PR TITLE
docs: strengthen Docs MCP usage instruction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,7 @@ Quality bar:
 
 ## Docs MCP
 
-When working on OpenAI API / Agents SDK / Codex details, consult the OpenAI Developer Docs MCP server via Codex:
+Always use the OpenAI developer documentation MCP server if you need to work with the OpenAI API, Agents SDK, Codex, etc., without me having to explicitly ask.
+
 - MCP name: `openaiDeveloperDocs`
 - URL: https://developers.openai.com/mcp


### PR DESCRIPTION
Updates AGENTS.md to include the recommended “always use docs MCP” instruction.

Docs MCP:
- name: openaiDeveloperDocs
- url: https://developers.openai.com/mcp
