### PR TITLE
chore: ralph codex xhigh defaults

### DIFF
--- a/scripts/ralph/ralph.sh
+++ b/scripts/ralph/ralph.sh
@@ -43,7 +43,12 @@ ALLOW_MAIN="${RALPH_ALLOW_MAIN:-0}"
 WORKTREES_DIR="${RALPH_WORKTREES_DIR:-$ROOT_DIR/.ralph-worktrees}"
 
 MODEL="${CODEX_MODEL:-gpt-5.2-codex}"
-REASONING_EFFORT="${CODEX_REASONING_EFFORT:-high}"
+
+# Codex CLI execution defaults (override via env when needed)
+# NOTE: Our convention is to pass approvals/sandbox/model/config at the top-level `codex` command.
+ASK_FOR_APPROVAL="${CODEX_ASK_FOR_APPROVAL:-on-request}"
+SANDBOX_MODE="${CODEX_SANDBOX:-workspace-write}"
+REASONING_EFFORT="${CODEX_REASONING_EFFORT:-xhigh}"
 
 PROMPT_TEMPLATE="${PROMPT_TEMPLATE:-$ROOT_DIR/scripts/ralph/prompt.codex.md}"
 
@@ -202,7 +207,12 @@ while [[ "$ITER" -le "$MAX_ITERATIONS" ]]; do
   echo "Iteration $ITER/$MAX_ITERATIONS: story $STORY_ID"
 
   # fresh codex run for this story
-  render_prompt "$STORY_ID" | codex exec --full-auto -m "$MODEL" -c "reasoning.effort=\"$REASONING_EFFORT\"" -
+  render_prompt "$STORY_ID" | codex \
+    --ask-for-approval "$ASK_FOR_APPROVAL" \
+    --sandbox "$SANDBOX_MODE" \
+    -m "$MODEL" \
+    -c "model_reasoning_effort=\"$REASONING_EFFORT\"" \
+    exec --full-auto -
 
   # runner owns checks + commit
   run_checks


### PR DESCRIPTION
### What
Updates `scripts/ralph/ralph.sh` so each story runs in its own Codex CLI run with the defaults we want for the Ralph loop.

### Changes
- Default reasoning effort to **xhigh** (`CODEX_REASONING_EFFORT` override still supported)
- Use config override key **`model_reasoning_effort`**
- Add env overrides:
  - `CODEX_ASK_FOR_APPROVAL` (default: `on-request`)
  - `CODEX_SANDBOX` (default: `workspace-write`)
- Pass approvals/sandbox/model/config at the top-level `codex` invocation (instead of attaching model/config to `codex exec`).

### Safety
- Script semantics unchanged beyond the Codex invocation + defaults.

### How to use
```bash
CODEX_REASONING_EFFORT=xhigh \
CODEX_ASK_FOR_APPROVAL=on-request \
CODEX_SANDBOX=workspace-write \
./scripts/ralph/ralph.sh
```
