### PR TITLE
admin: distill now (manual trigger per scope)

### DIFF
--- a/apps/admin/frontend/sessions.js
+++ b/apps/admin/frontend/sessions.js
@@ -17,6 +17,11 @@ export const buildPurgeSessionUrl = (gatewayBase, scopeId, confirm) => {
   return url.toString();
 };
 
+export const buildDistillSessionUrl = (gatewayBase, scopeId) => {
+  const base = gatewayBase.endsWith('/') ? gatewayBase.slice(0, -1) : gatewayBase;
+  return `${base}/sessions/${encodeURIComponent(scopeId)}/distill`;
+};
+
 export const formatSessionsError = (error, gatewayBase) => {
   const reason = error instanceof Error ? error.message : String(error);
   return [

--- a/apps/admin/frontend/styles.css
+++ b/apps/admin/frontend/styles.css
@@ -150,6 +150,14 @@ h1 {
   gap: 8px;
 }
 
+.sessions__result {
+  margin-top: 6px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: #6b5f4c;
+  overflow-wrap: anywhere;
+}
+
 .status--error {
   background: #ffe6e6;
   border-color: #e9a2a2;

--- a/docs/08-roadmap.md
+++ b/docs/08-roadmap.md
@@ -23,6 +23,7 @@ Issue: https://github.com/dctmfoo/openai-agents/issues/29
 ## Next
 
 ### M6: Distillation triggers + failure handling
+- Admin "Distill now" control (manual trigger per scope)
 - When do we distill? (on compaction vs every N messages)
 - What happens on distillation failure? (log + continue)
 

--- a/src/apps/admin/adminSessions.test.ts
+++ b/src/apps/admin/adminSessions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildClearSessionUrl,
   buildPurgeSessionUrl,
+  buildDistillSessionUrl,
   buildSessionsUrl,
   formatSessionsError,
   formatSessionsPayload,
@@ -26,6 +27,12 @@ describe('admin sessions helpers', () => {
   it('buildPurgeSessionUrl appends confirmation', () => {
     expect(buildPurgeSessionUrl('http://x', 'scope-1', 'scope-1')).toBe(
       'http://x/sessions/scope-1/purge?confirm=scope-1',
+    );
+  });
+
+  it('buildDistillSessionUrl encodes scope id', () => {
+    expect(buildDistillSessionUrl('http://x', 'telegram:889348242')).toBe(
+      'http://x/sessions/telegram%3A889348242/distill',
     );
   });
 

--- a/src/apps/admin/sessions.ts
+++ b/src/apps/admin/sessions.ts
@@ -26,6 +26,11 @@ export const buildPurgeSessionUrl = (
   return url.toString();
 };
 
+export const buildDistillSessionUrl = (gatewayBase: string, scopeId: string): string => {
+  const base = gatewayBase.endsWith('/') ? gatewayBase.slice(0, -1) : gatewayBase;
+  return `${base}/sessions/${encodeURIComponent(scopeId)}/distill`;
+};
+
 export const formatSessionsError = (error: unknown, gatewayBase: string): string => {
   const reason = error instanceof Error ? error.message : String(error);
   return [


### PR DESCRIPTION
Adds a manual admin control to trigger deterministic distillation for a selected session/scope.

Changes:
- Admin API: POST /sessions/:scopeId/distill
- Admin UI: per-session "Distill now" button + inline result text
- Tests for success + distillation_disabled
- Roadmap note (M6)

Verification:
- pnpm test
- pnpm build