### PR TITLE
feat: runtime logging + shell model guard + architecture discussion docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,12 +151,20 @@ Quality bar:
 
 See [docs/PROJECT-OVERVIEW.md](docs/PROJECT-OVERVIEW.md) for current milestone and feature status.
 
-## Docs MCP
+## Docs MCP (authoritative OpenAI docs loop — required)
 
-Always use the OpenAI developer documentation MCP server if you need to work with the OpenAI API, Agents SDK, Codex, etc., without me having to explicitly ask.
+Always use the OpenAI developer documentation MCP server whenever work touches OpenAI APIs/SDK behavior (models, tools, Responses API, Agents SDK semantics, etc.).
 
 - MCP name: `openaiDeveloperDocs`
 - URL: https://developers.openai.com/mcp
+
+Required workflow:
+1. Query docs first (before designing or coding) for the exact feature/behavior being changed.
+2. Capture at least one canonical reference in your plan/PR notes (doc URL + short takeaway).
+3. If behavior is ambiguous, verify with a minimal reproducible API probe and record both docs + probe evidence.
+4. Do not rely on memory or assumptions for SDK defaults/model-tool compatibility.
+
+If MCP is unavailable, explicitly state that as a blocker in your handoff and avoid presenting uncertain claims as facts.
 
 ## Dead Code / Unused Exports (knip)
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,63 @@
+.PHONY: help install install-admin install-all gateway gateway-prod admin logs chat-dashboard
+
+help:
+	@echo "Available targets:"
+	@echo "  make install          # Install root dependencies"
+	@echo "  make install-admin    # Install apps/admin dependencies"
+	@echo "  make install-all      # Install both root + admin deps"
+	@echo "  make gateway          # Run gateway (Telegram bot + admin API) in dev mode"
+	@echo "  make gateway-prod     # Build and run gateway from dist"
+	@echo "  make admin            # Run the Tauri admin app"
+	@echo "  make logs             # Tail runtime + event logs from HALO_HOME"
+	@echo "  make chat-dashboard   # Run gateway + log tail + Tauri admin together"
+
+install:
+	pnpm install
+
+install-admin:
+	cd apps/admin && pnpm install
+
+install-all: install install-admin
+
+gateway:
+	pnpm exec tsx src/gateway/start.ts
+
+gateway-prod:
+	pnpm build
+	pnpm start:gateway
+
+admin:
+	cd apps/admin && pnpm tauri:dev
+
+logs:
+	@bash -c 'set -euo pipefail; \
+		HALO_HOME_DIR="$${HALO_HOME:-$$HOME/.halo}"; \
+		LOG_DIR_PATH="$${LOG_DIR:-$$HALO_HOME_DIR/logs}"; \
+		mkdir -p "$$LOG_DIR_PATH"; \
+		touch "$$LOG_DIR_PATH/runtime.jsonl" "$$LOG_DIR_PATH/events.jsonl"; \
+		echo "Tailing logs from $$LOG_DIR_PATH"; \
+		tail -n 40 -F "$$LOG_DIR_PATH/runtime.jsonl" "$$LOG_DIR_PATH/events.jsonl"'
+
+chat-dashboard:
+	@bash -c 'set -euo pipefail; \
+		HALO_HOME_DIR="$${HALO_HOME:-$$HOME/.halo}"; \
+		LOG_DIR_PATH="$${LOG_DIR:-$$HALO_HOME_DIR/logs}"; \
+		HOST="$${GATEWAY_HOST:-127.0.0.1}"; \
+		PORT="$${GATEWAY_PORT:-8787}"; \
+		if [ -z "$${TELEGRAM_BOT_TOKEN:-}" ]; then \
+			echo "ERROR: TELEGRAM_BOT_TOKEN is not set"; \
+			exit 1; \
+		fi; \
+		mkdir -p "$$LOG_DIR_PATH"; \
+		touch "$$LOG_DIR_PATH/runtime.jsonl" "$$LOG_DIR_PATH/events.jsonl"; \
+		echo "Starting gateway on $$HOST:$$PORT..."; \
+		echo "HALO_HOME=$$HALO_HOME_DIR"; \
+		echo "LOG_DIR=$$LOG_DIR_PATH"; \
+		pnpm exec tsx src/gateway/start.ts & \
+		GATEWAY_PID=$$!; \
+		tail -n 0 -F "$$LOG_DIR_PATH/events.jsonl" & \
+		TAIL_PID=$$!; \
+		trap "echo Stopping gateway + log tail...; kill $$TAIL_PID $$GATEWAY_PID 2>/dev/null || true" EXIT INT TERM; \
+		sleep 2; \
+		echo "Starting Tauri admin app..."; \
+		cd apps/admin && pnpm tauri:dev'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-admin install-all gateway gateway-prod admin logs chat-dashboard
+.PHONY: help install install-admin install-all gateway gateway-supervised gateway-prod admin logs chat-dashboard
 
 help:
 	@echo "Available targets:"
@@ -6,6 +6,7 @@ help:
 	@echo "  make install-admin    # Install apps/admin dependencies"
 	@echo "  make install-all      # Install both root + admin deps"
 	@echo "  make gateway          # Run gateway (Telegram bot + admin API) in dev mode"
+	@echo "  make gateway-supervised # Run gateway with restart supervisor (/restart support)"
 	@echo "  make gateway-prod     # Build and run gateway from dist"
 	@echo "  make admin            # Run the Tauri admin app"
 	@echo "  make logs             # Tail runtime + event logs from HALO_HOME"
@@ -20,7 +21,10 @@ install-admin:
 install-all: install install-admin
 
 gateway:
-	pnpm exec tsx src/gateway/start.ts
+	pnpm run dev:gateway
+
+gateway-supervised:
+	pnpm run dev:gateway:supervised
 
 gateway-prod:
 	pnpm build
@@ -53,7 +57,7 @@ chat-dashboard:
 		echo "Starting gateway on $$HOST:$$PORT..."; \
 		echo "HALO_HOME=$$HALO_HOME_DIR"; \
 		echo "LOG_DIR=$$LOG_DIR_PATH"; \
-		pnpm exec tsx src/gateway/start.ts & \
+		pnpm run dev:gateway:supervised & \
 		GATEWAY_PID=$$!; \
 		tail -n 0 -F "$$LOG_DIR_PATH/events.jsonl" & \
 		TAIL_PID=$$!; \

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ TELEGRAM_BOT_TOKEN=... pnpm start:gateway
 
 Gateway defaults to: `http://127.0.0.1:8787`
 
+For local supervised dev (supports Telegram `/restart` to trigger build+restart):
+
+```bash
+TELEGRAM_BOT_TOKEN=... pnpm dev:gateway:supervised
+```
+
 Run the Admin Console (Tauri v2):
 
 ```bash

--- a/docs/02-telegram-setup.md
+++ b/docs/02-telegram-setup.md
@@ -69,6 +69,7 @@ pnpm start:gateway
 - Unknown DMs are refused (and do not create a session).
 - Group chats are ignored unless the group matches `parentsGroup.telegramChatId` and the sender is in the family list.
 - Family config is loaded once at startup; restart to pick up changes.
+- Parent DMs support `/restart` (and `/br`) to request build+restart. This works when running with the supervisor (`pnpm dev:gateway:supervised` or `make gateway-supervised`).
 - `OPENAI_API_KEY` is required for real model calls (smoke tests stub the model).
 - Semantic memory background sync is built-in for active scopes when `semanticMemory.enabled=true`; cadence is `semanticMemory.syncIntervalMinutes`.
 - Telegram image messages are routed to direct vision analysis (`message:photo` and image `message:document` with `mime_type=image/*`).

--- a/docs/11-troubleshooting.md
+++ b/docs/11-troubleshooting.md
@@ -30,6 +30,14 @@
     - `PRIME_MODEL` (global)
     - `PRIME_SHELL_MODEL` (only when shell is present)
 
+## Restart command behavior
+
+- `/restart` or `/br` exits the runtime with code `43` (parent DM only).
+- To auto-build and come back up, run gateway under supervisor:
+  - `pnpm dev:gateway:supervised`
+  - or `make gateway-supervised`
+- If you run plain `pnpm dev:gateway`, `/restart` will stop the process but will not auto-restart.
+
 ## Logs and diagnostics
 
 - Structured event logs: `HALO_HOME/logs/events.jsonl`

--- a/docs/11-troubleshooting.md
+++ b/docs/11-troubleshooting.md
@@ -22,9 +22,19 @@
 - Group chats are ignored unless the group ID matches `parentsGroup.telegramChatId`.
 - Family config is loaded at startup. Restart after changing `family.json`.
 
+## Shell tool errors
+
+- `Tool 'shell' is not supported with gpt-4.1`: this model does not support the hosted shell tool.
+  - Prime auto-selects `gpt-5.1` when shell is enabled.
+  - Optional overrides:
+    - `PRIME_MODEL` (global)
+    - `PRIME_SHELL_MODEL` (only when shell is present)
+
 ## Logs and diagnostics
 
-- Telegram and Gateway logs: `HALO_HOME/logs/events.jsonl`
+- Structured event logs: `HALO_HOME/logs/events.jsonl`
+- Runtime operational logs: `HALO_HOME/logs/runtime.jsonl`
+- Local tail helper: `make logs`
 
 Admin tail endpoints (loopback-only):
 

--- a/docs/12-tools.md
+++ b/docs/12-tools.md
@@ -23,6 +23,8 @@ Shell access is deny-by-default with three gates:
 
 Allowlisting `"gog"` (or any other command name) in tool policy does **not** enable shell execution. The tool name is always `"shell"`; command-level control happens only via regex patterns.
 
+Model note: OpenAI rejects `shell` on `gpt-4.1`. Prime now auto-selects `gpt-5.1` whenever shell is available unless you override with `PRIME_MODEL` (global) or `PRIME_SHELL_MODEL` (shell-only).
+
 ## Registering a tool
 
 1. Implement the tool in `src/tools/`. Use `tool(...)` for local tools or `HostedTool` for OpenAI hosted tools.

--- a/docs/17-family-architecture-discussion-in-progress.md
+++ b/docs/17-family-architecture-discussion-in-progress.md
@@ -1,0 +1,229 @@
+# 17) Family Architecture Discussion (In Progress)
+
+**Status:** IN_PROGRESS (discussion-only, no implementation in this doc)  
+**Owner:** Wags + contributors  
+**Last updated:** 2026-02-16
+
+---
+
+## 1) Why this document exists
+
+This is a **functional-first architecture discussion doc**.
+
+Goal: agree on the right primitives and user flows before implementation, so the app is simple for families and safe by default.
+
+---
+
+## 2) Functional outcomes we want (plain language)
+
+### A) Onboarding should feel simple
+
+A parent should be able to:
+- start the app,
+- connect Telegram,
+- invite co-parent + kids,
+- enable family group behavior,
+- and be operational quickly without editing raw JSON by hand.
+
+### B) Parent control should be clear
+
+A parent should be able to:
+- enable/disable child capabilities,
+- choose/change model policy for parent/child contexts,
+- do this from admin dashboard (and later parent Telegram controls),
+- see what is currently active and why.
+
+### C) Memory privacy must never leak
+
+The bot must not expose parent-private data in child-visible contexts.
+
+Example requirement:
+- Parent discussed sensitive fee details in parent DM or parent-only scope.
+- In family/child-visible chat, bot can discuss “fees are high” but must not reveal exact private numbers unless policy explicitly allows.
+
+### D) Group behavior should be predictable
+
+In family group chats (parents + children + bot):
+- bot should be mention-gated by default,
+- respond based on who asked,
+- use only memory lanes allowed for that speaker + scope.
+
+---
+
+## 3) Non-negotiable design principles
+
+1. **Safety boundaries are code-level policy**, not prompt-only behavior.
+2. **Parents default to broad capability access** (within explicit safety guardrails).
+3. **Children default to restricted capabilities**; parent can opt-in extra access.
+4. **Model selection must be policy-driven and compatibility-aware**, not ad-hoc hardcoding.
+5. **Architecture must support extensible child profiles**, not fixed one-off branching forever.
+
+---
+
+## 4) OpenAI-doc-backed constraints (authoritative references)
+
+These facts should drive architecture decisions:
+
+1. Agents SDK default model behavior:
+   - if model not explicitly set, default is `gpt-4.1` (or `OPENAI_DEFAULT_MODEL`).
+   - Source: <https://openai.github.io/openai-agents-js/guides/models>
+
+2. Shell tool execution modes:
+   - hosted container mode and local shell mode are both supported.
+   - Source: <https://developers.openai.com/api/docs/guides/tools-shell.md>
+
+3. Hosted shell network policy:
+   - outbound network is off by default;
+   - org allowlist + request `network_policy` needed to enable;
+   - `domain_secrets` for protected calls.
+   - Source: <https://developers.openai.com/api/docs/guides/tools-shell.md>
+
+4. Skills behavior:
+   - skills are versioned bundles with `SKILL.md`;
+   - model can choose when to invoke unless explicitly instructed.
+   - Source: <https://developers.openai.com/api/docs/guides/tools-skills.md>
+
+5. Long-run context handling:
+   - server-side compaction and standalone `/responses/compact` are supported.
+   - Source: <https://developers.openai.com/api/docs/guides/context-management.md>
+
+---
+
+## 5) Candidate architecture primitives (discussion baseline)
+
+### 5.1 Identity primitive
+
+Represents human actors:
+- parent / co-parent / child,
+- profile metadata (age/profile policy),
+- channel identities (Telegram IDs, etc.).
+
+### 5.2 Scope primitive
+
+Represents where interaction happens:
+- parent DM,
+- child DM,
+- parents group,
+- family mixed group.
+
+### 5.3 Capability primitive
+
+Represents tool/skill availability policy:
+- defaults by role/profile,
+- overrides by parent,
+- optional per-scope tuning.
+
+### 5.4 Memory lane primitive
+
+Represents visibility classes, e.g.:
+- parent-private,
+- parent-shared,
+- child-private (profile dependent),
+- child-shared,
+- family-shared/group-shared.
+
+### 5.5 Model policy primitive
+
+Resolves model from:
+- role/profile/scope policy,
+- required capability set,
+- compatibility checks,
+- explicit parent override.
+
+### 5.6 Runtime decision primitive
+
+For each message, produce a deterministic decision envelope:
+- who is speaking,
+- where,
+- mention intent,
+- allowed capabilities,
+- allowed memory lanes,
+- selected model,
+- rationale (for observability/admin UI).
+
+---
+
+## 6) Onboarding design target (functional flow)
+
+### Step 1: Parent bootstrap
+- parent verifies ownership in Telegram DM,
+- app creates initial family admin principal.
+
+### Step 2: Add family members
+- parent adds co-parent/children via guided flow,
+- assigns profiles (extensible categories).
+
+### Step 3: Default policies applied automatically
+- parent/co-parent: broad capabilities enabled,
+- children: restricted defaults,
+- memory lanes configured per profile policy.
+
+### Step 4: Group setup
+- configure parents group and family group,
+- family group mention mode enabled by default.
+
+### Step 5: Safety check screen
+- show “what bot can/can’t access per context” in plain language.
+
+---
+
+## 7) Architecture options to decide
+
+### Option A — Incremental patching of current config shape
+
+Pros:
+- less short-term churn.
+
+Cons:
+- risks long-term complexity and policy drift,
+- still difficult onboarding UX.
+
+### Option B — Control-plane first (recommended)
+
+Pros:
+- clear policy model,
+- clean parent controls,
+- better foundation for memory/model safety.
+
+Cons:
+- moderate upfront design effort.
+
+**Current recommendation:** Option B.
+
+---
+
+## 8) Discussion checkpoints (to lock before coding)
+
+1. **Profile model:** keep current age groups vs introduce extensible profile definitions now.
+2. **Memory lane contract:** exact lane names and which contexts can read/write each lane.
+3. **Parent defaults:** define exact capability set and safety exceptions.
+4. **Child defaults:** define baseline and opt-in escalation model.
+5. **Family group behavior:** mention-only vs mention+reply-chain behavior.
+6. **Model policy contract:** precedence order for defaults, overrides, compatibility failures.
+7. **Onboarding UX contract:** minimum required steps before “family-ready”.
+
+---
+
+## 9) Risks we must design around early
+
+1. **Private-memory leakage risk** via retrieval if lanes are not enforced in query path.
+2. **Model/tool mismatch risk** if compatibility is not validated before run.
+3. **Over-permissioned child experience** if defaults are not strict.
+4. **Operational confusion** if parent can’t see why a capability/model was chosen.
+
+---
+
+## 10) Next discussion iteration (proposed)
+
+In the next pass, lock these in order:
+
+1. Functional policy matrix (who can do what, where).
+2. Memory lane visibility matrix (read/write).
+3. Parent onboarding wizard steps and required screens.
+4. Model policy resolution order and override rules.
+
+---
+
+## 11) Change log
+
+- 2026-02-16: Initial in-progress discussion draft created (functional-first baseline).

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "main": "dist/index.js",
   "scripts": {
     "dev:telegram": "tsx src/interfaces/telegram/start.ts",
+    "dev:gateway": "tsx src/gateway/start.ts",
+    "dev:gateway:supervised": "bash scripts/dev/gateway-wrapper.sh",
     "dev:cli": "tsx src/interfaces/cli/run.ts",
     "build": "tsc -p tsconfig.json",
     "start:telegram": "node dist/interfaces/telegram/start.js",

--- a/plan/34-2026-02-16-parent-controlled-model-capabilities-and-multi-scope-memory-plan.md
+++ b/plan/34-2026-02-16-parent-controlled-model-capabilities-and-multi-scope-memory-plan.md
@@ -1,0 +1,205 @@
+# 34 — Parent-controlled models, capabilities, and multi-scope memory (planning spec)
+
+- Status: `DRAFT` (planning only, no implementation in this spec)
+- Date: `2026-02-16`
+- Owner: `unassigned`
+- Primary slice set: `plan/slices/S13/`
+
+## 1) Functional goal (what should work for your family)
+
+This plan targets a family-ready runtime where:
+
+1. Parents can use all available tools by default.
+2. Children start with tools off by default, but parents can enable specific capabilities.
+3. Model selection is configurable per role/scope/member and sourced from OpenAI (not hardcoded in app logic).
+4. Parents can change model/capabilities from:
+   - Tauri admin dashboard, and
+   - Telegram parent DM controls.
+5. Family chat supports parents + children with mention-based bot replies.
+6. Memory never leaks across private boundaries (especially parent private memory into child-visible contexts).
+7. Child privacy behavior is profile-driven and extensible (not locked to fixed hardcoded age enums).
+
+## 2) Concise requirement restatement (from Wags)
+
+- Remove ad-hoc model knobs like `SHELL_MODEL`; provide a proper model policy system.
+- Default to a model that can handle the enabled tool surface for the actor/context.
+- Parent should be able to switch to compatible models in Telegram parent chat.
+- Parent should be able to enable/disable child capabilities from admin dashboard.
+- Enable family onboarding for parent + co-parent + children with scoped behavior.
+- Add mixed family group behavior with mention routing and strict memory boundaries.
+- Design a robust multi-level memory system:
+  - parent private,
+  - shared/open memory,
+  - child private/shared depending on profile (e.g. <13 vs 13+).
+- Ensure OpenAI official docs are always consulted and referenced when implementing OpenAI behavior.
+
+## 3) Deep-dive findings from current codebase
+
+### 3.1 Why `gpt-4.1` happened
+
+- `src/prime/prime.ts` currently builds `new Agent({...})` without a guaranteed explicit model in baseline flow.
+- OpenAI Agents SDK default model applies when model is omitted.
+- SDK sources confirm default resolution behavior:
+  - `@openai/agents-core/dist/defaultModel.js` returns `OPENAI_DEFAULT_MODEL ?? 'gpt-4.1'`.
+  - `@openai/agents-core/dist/agent.d.ts` also documents default model behavior.
+
+### 3.2 Current policy/capability reality
+
+- Tool defaults are hardcoded in `src/policies/toolPolicy.ts` (`PARENT_ALLOWLIST`, `CHILD_ALLOWLIST`).
+- Parent default is **not** all tools today.
+- Child defaults are hardcoded by age enum (`child|teen|young_adult`).
+- Shell access requires both:
+  - `tools.shell.enabled`, and
+  - `tools.access` allowlist including `shell`.
+
+### 3.3 Current admin controls are read-heavy, not policy-write controls
+
+- `src/gateway/admin.ts` exposes status, sessions, distill, sync, retention actions.
+- It does **not** provide authoritative endpoints to mutate role/member model policy and child capability toggles.
+- `apps/admin/frontend/main.js` currently renders status/sessions/policy info but not parent control workflows for model/capability policy.
+
+### 3.4 Telegram policy limitations vs requested workflow
+
+- `src/interfaces/telegram/policy.ts` supports:
+  - DMs for known members,
+  - one `parents_group` where children are denied.
+- There is no family mixed group policy with mention-only behavior.
+- `src/interfaces/telegram/bot.ts` currently processes allowed group text directly (not mention-gated for a mixed parent+child family group mode).
+
+### 3.5 Memory model limitation vs requested privacy tiers
+
+- Scoped memory is currently one namespace per `scopeId` (`src/memory/scopedMemory.ts`).
+- Distillation writes only by scope (`src/memory/distillationRunner.ts`).
+- Semantic index/search is per scope (`src/memory/semanticMemory.ts`, `src/tools/semanticSearchTool.ts`) and lacks visibility tags/audience-class filtering.
+- This is insufficient for “private vs shared” memory partitions inside the same actor/group context.
+
+## 4) OpenAI docs + API evidence used for planning
+
+## 4.1 OpenAI Agents SDK docs (official)
+
+From `https://openai.github.io/openai-agents-js/guides/models`:
+
+- Default model is currently `gpt-4.1` when model is not specified.
+- `OPENAI_DEFAULT_MODEL` is supported as global default override.
+- Runner-level default model configuration is supported.
+
+From `https://openai.github.io/openai-agents-js/guides/tools`:
+
+- Hosted tools are OpenAI Responses API tools.
+- Shell tool behavior is explicit and can run local or hosted depending on `shellTool()` configuration.
+
+## 4.2 OpenAI API surface evidence
+
+- OpenAI `/models` list/retrieve exposes basic metadata only (id/object/created/owner), no tool-capability matrix:
+  - verified in generated official SDK source (`openai/src/resources/models.ts`).
+- Therefore, tool compatibility cannot be derived purely from `/models` metadata.
+- Compatibility needs a probe layer (minimal Responses calls) or an external authoritative compatibility endpoint (if introduced later).
+
+## 4.3 Live compatibility probes run during planning
+
+Using minimal `responses.create` probes for selected models:
+
+- `web_search_preview` accepted on tested models (`gpt-4.1`, `gpt-4.1-mini`, `gpt-5`, `gpt-5-mini`, `gpt-5.1`, `o4-mini`).
+- `shell` accepted in tested set only on `gpt-5.1`; others returned `400 Tool 'shell' is not supported ...`.
+
+Implication: model/tool compatibility must be runtime-checked and policy-driven.
+
+## 5) Recommended architecture direction
+
+## 5.1 Model selection (no hardcoded model IDs in business logic)
+
+Introduce a **Model Catalog + Capability Resolver**:
+
+1. Fetch available models from OpenAI `/models`.
+2. Probe required tool bundles using lightweight Responses calls.
+3. Cache support matrix with TTL.
+4. Resolve default model by required capability set per actor/scope.
+
+Policy resolution order:
+1. Explicit scope/member override (if any)
+2. Role/profile default policy
+3. Capability-compatible best candidate from catalog
+4. Safe fallback + explicit operator-visible error if none compatible
+
+## 5.2 Capability policy v2
+
+- Parent defaults: all registered capabilities enabled (subject to explicit blocklist if configured).
+- Child defaults: all optional capabilities disabled.
+- Parent can enable child capabilities per child/profile/scope from dashboard and Telegram parent controls.
+
+## 5.3 Family scope/policy v2
+
+Add mixed family-group support with strict routing:
+
+- Bot replies only when mentioned (or direct reply to bot message).
+- Access policy is speaker-aware + audience-aware.
+- Parents-group and family-group remain distinct policy scopes.
+
+## 5.4 Memory model v2 (audience-safe)
+
+Add multi-level memory channels with visibility tags and retrieval filters:
+
+- Parent private
+- Parent shared/open
+- Child shared (all child profiles)
+- Child private (for profiles that allow it, e.g. 13+)
+- Group shared memory
+
+Retrieval must enforce context visibility so child-visible contexts never include parent-private chunks.
+
+## 5.5 Child profile extensibility
+
+Replace fixed `ageGroup` enum dependency with configurable child profiles.
+
+Profiles should define:
+- capability defaults,
+- memory topology (shared/private),
+- transcript visibility rules,
+- future-safe extensibility (new profiles without TS union surgery).
+
+## 6) Options considered (and recommendation)
+
+### Option A: hardcoded approved model list per tool set
+- Fastest
+- Not acceptable long-term (drifts, brittle)
+
+### Option B: config-only manual model names
+- Flexible for operator
+- Still weak safety; no automatic compatibility proof
+
+### Option C (recommended): OpenAI model catalog + probe-backed compatibility matrix
+- Sourced from OpenAI list + direct API compatibility checks
+- Supports operator control + safe default auto-selection
+- Best fit for “future all-tools model” direction
+
+## 7) Acceptance criteria (functional)
+
+1. Parent DM works out-of-the-box with all parent-default capabilities.
+2. Child DM starts with restricted capabilities until parent enables selected ones.
+3. Parent can change model from dashboard and Telegram parent controls.
+4. In family group, bot responds only on mention and respects speaker-context permissions.
+5. Parent-private facts never appear in child-visible contexts.
+6. 13+ child private memory is not retrieved in group responses unless policy explicitly allows.
+7. Child profile categories are config-extensible.
+8. All OpenAI model/tool behavior claims in PRs are backed by docs + probe evidence.
+
+## 8) Out of scope for this planning track
+
+- Full production RBAC / auth for public admin endpoints.
+- Cross-provider routing beyond OpenAI model catalog.
+- Voice policy design.
+
+## 9) Slice execution map
+
+Implementation is decomposed in `plan/slices/S13/`:
+
+1. `S13-01` model catalog + capability probe contract
+2. `S13-02` model policy schema + resolver
+3. `S13-03` capability policy defaults + child toggle model
+4. `S13-04` parent config mutation service + admin write API
+5. `S13-05` Tauri parent controls UX
+6. `S13-06` Telegram parent command controls
+7. `S13-07` family group mention routing + scope policy
+8. `S13-08` child profile extensibility
+9. `S13-09` multi-level memory + semantic visibility filters
+10. `S13-10` migration/docs/phase gate

--- a/plan/README.md
+++ b/plan/README.md
@@ -1,0 +1,33 @@
+# Planning index
+
+Primary architecture specs:
+- `plan/34-2026-02-16-parent-controlled-model-capabilities-and-multi-scope-memory-plan.md` (active)
+
+Execution slices:
+- `plan/slices/S13/` (active)
+
+## How contributors/agents should use this plan
+
+1. Read the primary spec (`34-...plan.md`) first.
+2. Pick the next unclaimed slice in `plan/slices/S13/`.
+3. Set slice `Status` to `IN_PROGRESS`, fill `AssignedTo` + `StartedAt`.
+4. Implement only the slice scope (no opportunistic refactors).
+5. Run slice verification commands exactly as listed.
+6. Update slice status/evidence in the same commit:
+   - `Status: DONE`
+   - `CompletedBy`, `CompletedAt`, `CommitOrPR`, `VerificationEvidence`.
+
+## Mandatory quality gates
+
+Every slice must follow `AGENTS.md`:
+- TDD red → green → refactor
+- verification discipline
+- OpenAI Docs MCP authoritative docs loop
+
+Full handoff gates (unless slice explicitly states stricter gates):
+
+```bash
+pnpm test
+pnpm build
+pnpm check:deadcode
+```

--- a/scripts/dev/gateway-wrapper.sh
+++ b/scripts/dev/gateway-wrapper.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Supervisor loop for local gateway runtime.
+# Exit code contract:
+# - 43 => build + restart
+# - 0  => normal shutdown
+# - other => stop with same code
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+RESTART_EXIT_CODE="${HALO_RESTART_EXIT_CODE:-43}"
+RESTART_DELAY_SECONDS="${HALO_RESTART_DELAY_SECONDS:-1}"
+
+log_wrapper() {
+  echo "[gateway-wrapper] $1"
+}
+
+run_gateway() {
+  cd "$ROOT_DIR"
+  pnpm exec tsx src/gateway/start.ts
+}
+
+log_wrapper "using repo: $ROOT_DIR"
+
+while true; do
+  log_wrapper "starting gateway"
+
+  set +e
+  run_gateway
+  exit_code=$?
+  set -e
+
+  if [[ "$exit_code" -eq "$RESTART_EXIT_CODE" ]]; then
+    log_wrapper "restart requested (exit $exit_code). running build"
+
+    cd "$ROOT_DIR"
+    if ! pnpm build; then
+      log_wrapper "build failed; stopping"
+      exit 1
+    fi
+
+    log_wrapper "build complete; restarting in ${RESTART_DELAY_SECONDS}s"
+    sleep "$RESTART_DELAY_SECONDS"
+    continue
+  fi
+
+  if [[ "$exit_code" -eq 0 ]]; then
+    log_wrapper "gateway exited normally"
+    exit 0
+  fi
+
+  log_wrapper "gateway exited with code $exit_code"
+  exit "$exit_code"
+done

--- a/src/interfaces/telegram/bot.test.ts
+++ b/src/interfaces/telegram/bot.test.ts
@@ -684,6 +684,10 @@ describe('telegram adapter', () => {
     expect(exitSpy).toHaveBeenCalledWith(43);
     expect(timeoutSpy).toHaveBeenCalled();
 
+    const eventTypes = appendJsonl.mock.calls.map(([, record]) => record.type);
+    expect(eventTypes).toContain('telegram.restart');
+    expect(eventTypes).not.toContain('prime.run.success');
+
     exitSpy.mockRestore();
     timeoutSpy.mockRestore();
   });

--- a/src/interfaces/telegram/bot.ts
+++ b/src/interfaces/telegram/bot.ts
@@ -477,6 +477,16 @@ export function createTelegramAdapter(options: TelegramAdapterOptions): Telegram
       return;
     }
 
+    if (record.type === 'telegram.restart') {
+      runtimeLogger.info('telegram.restart', {
+        channel: record.data.channel ?? 'telegram',
+        scopeId: record.data.scopeId,
+        userId: record.data.userId,
+        command: record.data.command,
+      });
+      return;
+    }
+
     if (record.type === 'prime.run.success') {
       runtimeLogger.info('prime.run.success', {
         channel: record.data.channel,
@@ -868,7 +878,7 @@ export function createTelegramAdapter(options: TelegramAdapterOptions): Telegram
 
       await writeLog({
         ts: now().toISOString(),
-        type: 'prime.run.success',
+        type: 'telegram.restart',
         data: {
           channel: 'telegram',
           action: 'restart_requested',

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -5,6 +5,7 @@ export type EventLogRecord = {
   ts: string;
   type:
     | 'telegram.update'
+    | 'telegram.restart'
     | 'prime.run.start'
     | 'prime.run.success'
     | 'prime.run.error'

--- a/src/utils/runtimeLogger.ts
+++ b/src/utils/runtimeLogger.ts
@@ -1,0 +1,106 @@
+import { appendFile, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+type RuntimeLogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+type RuntimeLogRecord = {
+  ts: string;
+  level: RuntimeLogLevel;
+  component: string;
+  message: string;
+  data?: Record<string, unknown>;
+};
+
+type RuntimeLoggerOptions = {
+  logDir: string;
+  component: string;
+  level?: RuntimeLogLevel;
+  echoToConsole?: boolean;
+};
+
+const LOG_LEVEL_WEIGHT: Record<RuntimeLogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+
+const normalizeLevel = (value: string | undefined): RuntimeLogLevel => {
+  if (!value) return 'info';
+  const lowered = value.toLowerCase();
+  if (lowered === 'debug' || lowered === 'info' || lowered === 'warn' || lowered === 'error') {
+    return lowered;
+  }
+  return 'info';
+};
+
+export function serializeError(err: unknown): { name: string; message: string; stack?: string } | string {
+  if (err instanceof Error) {
+    return {
+      name: err.name,
+      message: err.message,
+      stack: err.stack,
+    };
+  }
+
+  return String(err);
+}
+
+type RuntimeLogger = {
+  debug: (message: string, data?: Record<string, unknown>) => void;
+  info: (message: string, data?: Record<string, unknown>) => void;
+  warn: (message: string, data?: Record<string, unknown>) => void;
+  error: (message: string, data?: Record<string, unknown>) => void;
+  child: (name: string) => RuntimeLogger;
+};
+
+export function createRuntimeLogger(options: RuntimeLoggerOptions): RuntimeLogger {
+  const threshold = normalizeLevel(options.level ?? process.env.HALO_LOG_LEVEL);
+  const echoToConsole = options.echoToConsole ?? process.env.NODE_ENV !== 'test';
+  const logPath = path.join(options.logDir, 'runtime.jsonl');
+
+  const write = async (level: RuntimeLogLevel, message: string, data?: Record<string, unknown>) => {
+    if (LOG_LEVEL_WEIGHT[level] < LOG_LEVEL_WEIGHT[threshold]) {
+      return;
+    }
+
+    const record: RuntimeLogRecord = {
+      ts: new Date().toISOString(),
+      level,
+      component: options.component,
+      message,
+      ...(data ? { data } : {}),
+    };
+
+    await mkdir(path.dirname(logPath), { recursive: true });
+    await appendFile(logPath, JSON.stringify(record) + '\n', 'utf8');
+
+    if (!echoToConsole) return;
+
+    const prefix = `[${record.ts}] [${record.level}] [${record.component}] ${record.message}`;
+    if (level === 'error' || level === 'warn') {
+      console.error(prefix, data ?? '');
+    } else {
+      console.log(prefix, data ?? '');
+    }
+  };
+
+  const fireAndForget = (level: RuntimeLogLevel, message: string, data?: Record<string, unknown>) => {
+    void write(level, message, data).catch((err) => {
+      const fallback = serializeError(err);
+      console.error(`[runtime-logger-failure] ${options.component}`, fallback);
+    });
+  };
+
+  return {
+    debug: (message, data) => fireAndForget('debug', message, data),
+    info: (message, data) => fireAndForget('info', message, data),
+    warn: (message, data) => fireAndForget('warn', message, data),
+    error: (message, data) => fireAndForget('error', message, data),
+    child: (name) =>
+      createRuntimeLogger({
+        ...options,
+        component: `${options.component}.${name}`,
+      }),
+  };
+}


### PR DESCRIPTION
## Summary
- Added structured runtime logging and wired gateway/telegram startup + error events.
- Added safe model selection for shell-enabled runs to avoid unsupported-model failures.
- Added Makefile helpers for local run and log tailing.
- Added/updated docs for troubleshooting, tools, and architecture discussion in-progress.

## Validation
- pnpm test
- pnpm build
- pnpm check:deadcode

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds structured runtime logging (`runtime.jsonl`), a Telegram `/restart` command with a supervised gateway wrapper, and a shell-aware model selection guard for Prime. It also includes substantial planning/architecture docs for future family features.

- **Runtime logger** (`src/utils/runtimeLogger.ts`): New fire-and-forget JSONL logger wired into gateway startup and telegram bot event flows. `serializeError` moved here from `bot.ts` as a shared utility.
- **Telegram `/restart`**: Parent-only DM command that exits with code 43, picked up by a new bash supervisor loop (`scripts/dev/gateway-wrapper.sh`) that rebuilds and restarts. Proper `telegram.restart` event type avoids collision with `prime.run.success`. Good test coverage for both allow and deny paths.
- **Shell model guard** (`src/prime/prime.ts`): `resolvePrimeModel` auto-selects `gpt-5.1` when shell tool is enabled, preventing `gpt-4.1` incompatibility errors. `PRIME_MODEL` / `PRIME_SHELL_MODEL` env vars provide operator overrides.
- **Makefile + scripts**: Dev helpers for gateway, supervised gateway, log tailing, and a composite chat-dashboard target.
- **Docs**: Troubleshooting entries for shell errors and restart behavior, enhanced AGENTS.md docs-MCP workflow, and new architecture discussion doc for family features (discussion-only, no implementation).

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor bug in the gateway error logging path that should be addressed.
- The core logic is sound — restart command is well-guarded (parent DM only), event types are properly separated, model selection guard is a good safety improvement, and test coverage is thorough. The fire-and-forget log before process.exit(1) in start.ts is a real bug but non-critical since reportStartupError provides redundant error persistence. The rest is docs and dev tooling with no risk.
- Pay close attention to `src/gateway/start.ts` (fire-and-forget log lost before process.exit) and `src/prime/prime.ts` (PRIME_MODEL override silently bypasses shell-safe guard).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/utils/runtimeLogger.ts | New structured runtime logger with fire-and-forget writes, log-level filtering, and child logger support. Minor perf concern: mkdir called on every write. |
| src/utils/logging.ts | Added 'telegram.restart' to EventLogRecord type union — clean, minimal change. |
| src/gateway/start.ts | Wired runtime logger for gateway startup. Bug: fire-and-forget logger.error() is called immediately before synchronous process.exit(1), so the log entry will be lost. |
| src/interfaces/telegram/bot.ts | Added /restart command handling with proper event type, runtime logger integration, slash command parser, and moved serializeError to shared module. Well-structured changes with good test coverage. |
| src/interfaces/telegram/bot.test.ts | New tests for /restart command: parent DM success path (exit code 43, correct event type) and child DM denial. Thorough assertions including event type verification. |
| src/prime/prime.ts | Added resolvePrimeModel to auto-select gpt-5.1 when shell is enabled. PRIME_MODEL global override silently bypasses shell-safe guard which could cause runtime failures. |
| Makefile | New Makefile with dev helpers for gateway, log tailing, and chat-dashboard composite target. Clean and well-organized. |
| scripts/dev/gateway-wrapper.sh | Supervisor loop script for gateway restart support. Clean exit code contract (43=restart, 0=normal, other=stop). Proper error handling for build failures. |
| package.json | Added dev:gateway and dev:gateway:supervised scripts, consistent with Makefile targets. |

</details>



<sub>Last reviewed commit: 06471ae</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=38a52679-04e0-4763-a19c-0b1e73299a06))

<!-- /greptile_comment -->